### PR TITLE
Changed text alterpassword_non_finalised_items

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -583,7 +583,7 @@
     <string name="alterpassword_title"><![CDATA[Update Passcode & Biometrics]]></string>
     <string name="alterpassword_desc">By pressing Continue, you will be guided through setting up a new passcode. You will also get the option of enabling biometrics, or to continue without them.</string>
     <string name="alterpassword_confirm">Continue</string>
-    <string name="alterpassword_non_finalised_items">All identities and accounts must be finalized before passcode can be changed. Please wait, then try again.</string>
+    <string name="alterpassword_non_finalised_items">All identities and accounts must be finalized before passcode can be changed. Please wait, then try again. If you have any failed identities, these must also be deleted first.</string>
 
     <!-- ***** Recipient ***** -->
 


### PR DESCRIPTION
## Purpose

Issue 54
https://github.com/Concordium/concordium-reference-wallet-android/issues/54

## Changes

Text changed. If user tries to change password/passcode when there is a failed/pending identity.

I have got the new text from Jens Ager Sørensen.

## Checklist

- [X] My code follows the style of this project.
- [X] The code compiles without warnings.
- [X] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.

## CLA acceptance

By submitting the contribution I accept the terms and conditions of the
Contributor License Agreement v1.0
- link: https://developers.concordium.com/CLAs/Contributor-License-Agreement-v1.0.pdf

- [X] I accept the above linked CLA.
