### PR TITLE
Gradle: Add plugin for printing the dependency tree of a given task

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,6 +14,12 @@ buildscript {
     }
 }
 
+plugins {
+    // Plugin that adds a task 'taskTree' for printing task dependency tree.
+    // Example: './gradlew build taskTree' prints the dependencies of the task 'build'.
+    id "com.dorongold.task-tree" version "2.1.1"
+}
+
 allprojects {
     repositories {
         google()


### PR DESCRIPTION
## Purpose

Add ability to gain insight to the dependency structure of Gradle tasks.

## Changes

Add Gradle plugin `Gradle Task Tree`.