### PR TITLE
CI: Build APKs and persist them as workflow artifacts

### DIFF
--- a/.github/workflows/build+test.yml
+++ b/.github/workflows/build+test.yml
@@ -35,8 +35,18 @@ jobs:
         with:
           name: coverage-report
           path: "${{github.workspace}}/app/build/reports/jacoco/unitTestCoverageReport/html/"
-      - name: Store generated APKs
+      - name: Store generated release build APK for stagenet
         uses: actions/upload-artifact@v3
         with:
-          name: apks
-          path: "${{github.workspace}}/app/build/outputs/apk/"
+          name: apk-stagenet-release
+          path: "${{github.workspace}}/app/build/outputs/apk/staging/release/"
+      - name: Store generated release build APK for testnet
+        uses: actions/upload-artifact@v3
+        with:
+          name: apk-testnet-release
+          path: "${{github.workspace}}/app/build/outputs/apk/prodTestNet/release/"
+      - name: Store generated release build APK for mainnet
+        uses: actions/upload-artifact@v3
+        with:
+          name: apk-mainnet-release
+          path: "${{github.workspace}}/app/build/outputs/apk/prodMainNet/release/"

--- a/.github/workflows/build+test.yml
+++ b/.github/workflows/build+test.yml
@@ -23,7 +23,7 @@ jobs:
           distribution: temurin
           cache: gradle # caches dependencies (https://github.com/actions/setup-java#caching-packages-dependencies)
       - name: Build project and run unit tests (local flavor)
-        run: ./gradlew test unitTestCoverageReport --no-daemon
+        run: ./gradlew build unitTestCoverageReport --no-daemon
       - name: Add coverage comment to PR
         # Action uses deprecated features (https://github.com/Madrapps/jacoco-report/issues/35).
         uses: madrapps/jacoco-report@v1.3
@@ -35,3 +35,8 @@ jobs:
         with:
           name: coverage-report
           path: "${{github.workspace}}/app/build/reports/jacoco/unitTestCoverageReport/html/"
+      - name: Store generated APKs
+        uses: actions/upload-artifact@v3
+        with:
+          name: apks
+          path: "${{github.workspace}}/app/build/outputs/apk/"


### PR DESCRIPTION
The APKs are quite big - around 75 MB each and we build 10 different variants (debug and release for 5 different flavors). So we store only the release builds of stagenet, testnet, and mainnet.

There should be a [500 MB](https://docs.github.com/en/billing/managing-billing-for-github-actions/about-billing-for-github-actions#about-billing-for-github-actions) limit, but I haven't seen it take effect yet.