### PR TITLE
Move upload to separate workflow

### DIFF
--- a/.github/workflows/build+test.yml
+++ b/.github/workflows/build+test.yml
@@ -23,7 +23,7 @@ jobs:
           distribution: temurin
           cache: gradle # caches dependencies (https://github.com/actions/setup-java#caching-packages-dependencies)
       - name: Build project and run unit tests (local flavor)
-        run: ./gradlew build unitTestCoverageReport --no-daemon
+        run: ./gradlew test unitTestCoverageReport --no-daemon
       - name: Add coverage comment to PR
         # Action uses deprecated features (https://github.com/Madrapps/jacoco-report/issues/35).
         uses: madrapps/jacoco-report@v1.3
@@ -35,18 +35,3 @@ jobs:
         with:
           name: coverage-report
           path: "${{github.workspace}}/app/build/reports/jacoco/unitTestCoverageReport/html/"
-      - name: Store generated release build APK for stagenet
-        uses: actions/upload-artifact@v3
-        with:
-          name: apk-stagenet-release
-          path: "${{github.workspace}}/app/build/outputs/apk/staging/release/"
-      - name: Store generated release build APK for testnet
-        uses: actions/upload-artifact@v3
-        with:
-          name: apk-testnet-release
-          path: "${{github.workspace}}/app/build/outputs/apk/prodTestNet/release/"
-      - name: Store generated release build APK for mainnet
-        uses: actions/upload-artifact@v3
-        with:
-          name: apk-mainnet-release
-          path: "${{github.workspace}}/app/build/outputs/apk/prodMainNet/release/"

--- a/.github/workflows/build+upload.yml
+++ b/.github/workflows/build+upload.yml
@@ -1,0 +1,52 @@
+name: Build and upload
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag-override:
+        description: "Tag"
+        type: string
+        required: false
+
+env:
+  java-version: "17"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Apply tag override and parse ref"
+        uses: bisgardo/github-action-parse-ref@v1
+        id: ref
+        with:
+          ref: "${{github.event.inputs.tag-override || github.ref}}"
+          default-ref-type: tags
+      - name: Fail if ref is not a tag
+        if: "steps.ref.outputs.ref-type != 'tags'"
+        run: exit 1
+      - uses: actions/checkout@v3
+        with:
+          ref: "${{steps.ref.outputs.ref-name}}"
+      - name: "Set up JDK"
+        uses: actions/setup-java@v3
+        with:
+          java-version: "${{env.java-version}}"
+          distribution: temurin
+          cache: gradle # caches dependencies (https://github.com/actions/setup-java#caching-packages-dependencies)
+      - name: "Build project and run unit tests"
+        run: ./gradlew build --no-daemon
+      - name: Store generated release build APK for stagenet
+        uses: actions/upload-artifact@v3
+        with:
+          name: apk-stagenet-release
+          path: "${{github.workspace}}/app/build/outputs/apk/staging/release/"
+      - name: "Store generated release build APK for testnet"
+        uses: actions/upload-artifact@v3
+        with:
+          name: apk-testnet-release
+          path: "${{github.workspace}}/app/build/outputs/apk/prodTestNet/release/"
+      - name: "Store generated release build APK for mainnet"
+        uses: actions/upload-artifact@v3
+        with:
+          name: apk-mainnet-release
+          path: "${{github.workspace}}/app/build/outputs/apk/prodMainNet/release/"


### PR DESCRIPTION
## Purpose

Reduce the resources usage of the verification workflow in terms of computational resources and persistent storage by not building and uploading artifacts in each run.

## Changes

Do the upload in a separate workflow that is run manually and has to be run from a tag.