### PR TITLE
CIS-2 add memo fix

### DIFF
--- a/app/src/main/java/com/concordium/wallet/ui/cis2/SendTokenActivity.kt
+++ b/app/src/main/java/com/concordium/wallet/ui/cis2/SendTokenActivity.kt
@@ -16,6 +16,7 @@ import androidx.appcompat.widget.PopupMenu
 import androidx.core.content.ContextCompat
 import androidx.core.widget.addTextChangedListener
 import com.bumptech.glide.Glide
+import com.concordium.wallet.CBORUtil
 import com.concordium.wallet.R
 import com.concordium.wallet.data.model.Token
 import com.concordium.wallet.data.room.Account
@@ -207,9 +208,8 @@ class SendTokenActivity : BaseActivity() {
         registerForActivityResult(ActivityResultContracts.StartActivityForResult()) {
             if (it.resultCode == Activity.RESULT_OK) {
                 it.data?.getStringExtra(AddMemoActivity.EXTRA_MEMO)?.let { memo ->
-                    binding.memo.text = memo
                     binding.memoClear.visibility = View.VISIBLE
-                    viewModel.sendTokenData.memo = memo
+                    handleMemo(memo)
                 }
             }
         }
@@ -233,6 +233,26 @@ class SendTokenActivity : BaseActivity() {
                 }
             }
         }
+
+    private fun handleMemo(memo: String?) {
+        if (memo != null && memo.isNotEmpty()) {
+            viewModel.setMemo(CBORUtil.encodeCBOR(memo))
+            setMemoText(memo)
+        } else {
+            viewModel.setMemo(null)
+            setMemoText("")
+        }
+    }
+
+    private fun setMemoText(memo: String) {
+        if (memo.isNotEmpty()) {
+            binding.memo.text = memo
+            binding.memoClear.visibility = View.VISIBLE
+        } else {
+            binding.memo.text = getString(R.string.send_funds_optional_add_memo)
+            binding.memoClear.visibility = View.INVISIBLE
+        }
+    }
 
     private fun showPopupPaste(clipText: String) {
         val popupMenu = PopupMenu(this, binding.receiver)

--- a/app/src/main/java/com/concordium/wallet/ui/cis2/SendTokenActivity.kt
+++ b/app/src/main/java/com/concordium/wallet/ui/cis2/SendTokenActivity.kt
@@ -234,8 +234,8 @@ class SendTokenActivity : BaseActivity() {
             }
         }
 
-    private fun handleMemo(memo: String?) {
-        if (memo != null && memo.isNotEmpty()) {
+    private fun handleMemo(memo: String) {
+        if (memo.isNotEmpty()) {
             viewModel.setMemo(CBORUtil.encodeCBOR(memo))
             setMemoText(memo)
         } else {

--- a/app/src/main/java/com/concordium/wallet/ui/cis2/SendTokenViewModel.kt
+++ b/app/src/main/java/com/concordium/wallet/ui/cis2/SendTokenViewModel.kt
@@ -153,11 +153,7 @@ class SendTokenViewModel(application: Application) : AndroidViewModel(applicatio
     }
 
     fun setMemo(memo: ByteArray?) {
-        if (memo != null) {
-            sendTokenData.memo = memo.toHex()
-        } else {
-            sendTokenData.memo = null
-        }
+        sendTokenData.memo = memo?.toHex();
         loadTransactionFee()
     }
 

--- a/app/src/main/java/com/concordium/wallet/ui/cis2/SendTokenViewModel.kt
+++ b/app/src/main/java/com/concordium/wallet/ui/cis2/SendTokenViewModel.kt
@@ -25,6 +25,7 @@ import com.concordium.wallet.ui.account.common.accountupdater.AccountUpdater
 import com.concordium.wallet.ui.common.BackendErrorHandler
 import com.concordium.wallet.util.DateTimeUtil
 import com.concordium.wallet.util.Log
+import com.concordium.wallet.util.toHex
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -149,6 +150,15 @@ class SendTokenViewModel(application: Application) : AndroidViewModel(applicatio
                 waiting.postValue(false)
                 handleBackendError(it)
             })
+    }
+
+    fun setMemo(memo: ByteArray?) {
+        if (memo != null) {
+            sendTokenData.memo = memo.toHex()
+        } else {
+            sendTokenData.memo = null
+        }
+        loadTransactionFee()
     }
 
     fun loadTransactionFee() {


### PR DESCRIPTION
## Purpose

Sending a CCD tokens from the CIS-2 flow failed if memo is added to the transaction.


## Changes

The memo was sent as a plain String, now its is first encoded with CBORUtil and the resulting ByteArray is converted to Hex String. This fixed the issue with the wallet_lib failing.

