### PR TITLE
CI: Fix coverage collection for tests run by roboelectric

### DIFF
--- a/.github/workflows/build+test.yml
+++ b/.github/workflows/build+test.yml
@@ -23,7 +23,7 @@ jobs:
           distribution: temurin
           cache: gradle # caches dependencies (https://github.com/actions/setup-java#caching-packages-dependencies)
       - name: Build project and run unit tests (local flavor)
-        run: ./gradlew test unitTestCoverageReport --no-daemon
+        run: ./gradlew test unitTestCoverageReport --stacktrace
       - name: Add coverage comment to PR
         # Action uses deprecated features (https://github.com/Madrapps/jacoco-report/issues/35).
         uses: madrapps/jacoco-report@v1.3

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -4,13 +4,13 @@ plugins {
     id 'com.android.application'
     id 'kotlin-android'
     id 'kotlin-kapt'
+    id 'jacoco'
 }
 
 // Create task for reporting test coverage on unit tests run against the debug build of the "local" flavor.
-// Note that by enabling 'testCoverageEnabled' for the 'debug' build type,
-// the tasks 'create${flavor}CoverageReport' are automatically generated for all flavors.
+// Note that enabling 'testCoverageEnabled' for the 'debug' build type would create
+// the tasks 'create${flavor}CoverageReport' automatically for all flavors.
 // However, these tasks include running integration tests which require a device to be connected.
-// TODO It's unclear if this should be wrapped in 'project.afterEvaluate' (it seems unnecessary but some guides include it).
 tasks.create(name: "unitTestCoverageReport", type: JacocoReport, dependsOn: "testLocalDebugUnitTest") {
     group = "Verification" // existing group containing tasks for generating linting reports etc.
     description = "Generate Jacoco coverage reports for the 'local' debug build."
@@ -22,14 +22,20 @@ tasks.create(name: "unitTestCoverageReport", type: JacocoReport, dependsOn: "tes
 
     // Execution data generated when running the tests against classes instrumented by the JaCoCo agent.
     // This is enabled with 'testCoverageEnabled' in the 'debug' build type.
-    executionData.from = files("${project.buildDir}/outputs/unit_test_code_coverage/localDebugUnitTest/testLocalDebugUnitTest.exec")
+    executionData.from = "${project.buildDir}/outputs/unit_test_code_coverage/localDebugUnitTest/testLocalDebugUnitTest.exec"
 
     // Compiled Kotlin class files are written into build-variant-specific subdirectories of 'build/tmp/kotlin-classes'.
     // JaCoCo execution data is a record of the (offsets of?) executed bytecode instructions which are looked up in the class files.
-    classDirectories.from = files([fileTree(dir: "${project.buildDir}/tmp/kotlin-classes/localDebug")])
+    classDirectories.from = "${project.buildDir}/tmp/kotlin-classes/localDebug"
 
     // To produce an accurate report, the bytecode is mapped back to the original source code.
-    sourceDirectories.from = files(["${project.projectDir}/src/main/java"])
+    sourceDirectories.from = "${project.projectDir}/src/main/java"
+}
+
+// Necessary for coverage to be collected for tests executed by 'RobolectricTestRunner'.
+tasks.withType(Test) {
+    jacoco.includeNoLocationClasses = true
+    jacoco.excludes = ['jdk.internal.*']
 }
 
 def versionBuildNumberSequential = 33
@@ -141,7 +147,7 @@ android {
         }
         debug {
             debuggable true
-            testCoverageEnabled true
+            enableUnitTestCoverage true
         }
     }
 


### PR DESCRIPTION
The roboelectric runner apparently generates new classes, so including "no location classes" is necessary (which in turn necessitates excluding `jdk.internal.*`).

Included a few other simplifications to the configuration that I found to not change the end result.

The change is prompted by the observation that coverage data wasn't collected for the new tests in https://github.com/Concordium/concordium-reference-wallet-android/pull/203.