### PR TITLE
Fix adding fungible tokens as collectibles

### DIFF
--- a/app/src/main/java/com/concordium/wallet/ui/cis2/TokensViewModel.kt
+++ b/app/src/main/java/com/concordium/wallet/ui/cis2/TokensViewModel.kt
@@ -219,7 +219,7 @@ class TokensViewModel(application: Application) : AndroidViewModel(application) 
                                 tokenData.contractIndex,
                                 selectedToken.token,
                                 account.address,
-                                selectedToken.tokenMetadata?.unique ?: false,
+                                !(selectedToken.tokenMetadata?.unique ?: false),
                                 selectedToken.tokenMetadata,
                                 tokenData.contractName
                             )
@@ -305,7 +305,7 @@ class TokensViewModel(application: Application) : AndroidViewModel(application) 
                                     tokenData.contractIndex,
                                     selectedToken.token,
                                     account.address,
-                                    selectedToken.tokenMetadata?.unique ?: false,
+                                    !(selectedToken.tokenMetadata?.unique ?: false),
                                     selectedToken.tokenMetadata,
                                     tokenData.contractName
                                 )


### PR DESCRIPTION
## Purpose

Fixes adding fungible CIS2 tokens as collectibles. As I understood, if the token metadata has the "unique" flag set to "false", it means that it is a fungible token, but the wallet threats such tokens as collectibles.

## Changes

- Incorrect setting of `ContractToken.isFungible` field in `TokensViewModel`

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.

## CLA acceptance

By submitting the contribution I accept the terms and conditions of the
Contributor License Agreement v1.0
- link: https://developers.concordium.com/CLAs/Contributor-License-Agreement-v1.0.pdf

- [x] I accept the above linked CLA.
