### PR TITLE
Bugfix/cbw 1059 crash on amount input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added CHANGELOG.md
 - Identity view: Display raw "document type" when no localized string is matched
 
+### Fixed
+
+- Fix a crash when inputting a too large amount as the stake for delegation or baking.
+
 ### Changed
 
 - Changed Terms and Conditions screen to new UI.

--- a/app/src/main/java/com/concordium/wallet/ui/bakerdelegation/common/StakeAmountInputValidator.kt
+++ b/app/src/main/java/com/concordium/wallet/ui/bakerdelegation/common/StakeAmountInputValidator.kt
@@ -70,7 +70,7 @@ class StakeAmountInputValidator(
     }
 
     private fun checkAmount(amount: String): StakeError {
-        if (amount.toLongOrNull() == null) StakeError.UNKNOWN
+        if (amount.toLongOrNull() == null) return StakeError.NOT_ENOUGH_FUND
         return StakeError.OK
     }
 

--- a/app/src/test/java/com/concordium/wallet/ui/bakerdelegation/common/StakeAmountInputValidatorTest.kt
+++ b/app/src/test/java/com/concordium/wallet/ui/bakerdelegation/common/StakeAmountInputValidatorTest.kt
@@ -1,0 +1,19 @@
+package com.concordium.wallet.ui.bakerdelegation.common
+
+import org.junit.Assert
+import org.junit.Test
+
+class StakeAmountInputValidatorTest {
+
+    @Test
+    fun notEnoughFundIfAmountIsGreaterThanLong() {
+        val validator = StakeAmountInputValidator(
+            null, "12345678912345", null, null, null, null, null, null, null, null
+        )
+        val tooBigAmount = "53151357135135000000"
+
+        val validationResult = validator.validate(tooBigAmount, null)
+
+        Assert.assertEquals(StakeAmountInputValidator.StakeError.NOT_ENOUGH_FUND, validationResult)
+    }
+}


### PR DESCRIPTION
## Purpose
Fix an issue in the baking and delegation where setting a too large amount (greater than what can be stored in a Long) caused a crash.

Please note that this is just a quickfix. In the future the input field should be updated so that it prevents the user to input invalid values like how it is in the iOS app.

## Changes
- Correctly return an error when amount is not a Long.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.