### PR TITLE
Reload token thumbnails when switching to tokens without a thumbnail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fix a crash when inputting a too large amount as the stake for delegation or baking.
+- Fix an issue where another tokens image was sometimes shown for tokens without an image.
 
 ### Changed
 

--- a/app/src/main/java/com/concordium/wallet/ui/cis2/SendTokenActivity.kt
+++ b/app/src/main/java/com/concordium/wallet/ui/cis2/SendTokenActivity.kt
@@ -283,9 +283,9 @@ class SendTokenActivity : BaseActivity() {
             if (token.isCCDToken) {
                 Glide.with(this).load(R.drawable.ic_concordium_logo_no_text).into(binding.searchToken.tokenIcon)
             } else {
-                token.tokenMetadata?.thumbnail?.let { thumbnail ->
+                token.tokenMetadata?.thumbnail.let { thumbnail ->
                     Glide.with(this)
-                        .load(thumbnail.url)
+                        .load(thumbnail?.url)
                         .placeholder(R.drawable.ic_token_loading_image)
                         .override(iconSize)
                         .fitCenter()


### PR DESCRIPTION
## Purpose
Fix an issue where the thumbnail of the wrong token could be shown to the user. This happened exactly when on a token with a thumbnail and then selecting a thumbnail-less token, i.e. the image would not be updated in this case.

## Changes
- Reload thumbnail even though the thumbnail is not present in the token (as the no image icon is loaded in this case). Note that it is fine to load on a null URL according to the Glide docs (https://bumptech.github.io/glide/doc/getting-started.html#listview-and-recyclerview).

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.