### PR TITLE
Bugfix/cbw 1061 wrong token details shown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   5. NFT token details screen should not have Decimal section.
   6. Token image size is very small, contents almost invisible.
 - Fixed issue where owned tokens are not reflected in search result list and details screens
+- When adding a new token the token details would in some cases show information from another token.
 
 ### Changed
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -40,11 +40,11 @@ tasks.withType(Test) {
     jacoco.excludes = ['jdk.internal.*']
 }
 
-def versionBuildNumberSequential = 34
+def versionBuildNumberSequential = 36
 
 def versionBuildNumberMajor = 1
-def versionBuildNumberMinor = 1
-def versionBuildNumberPatch = 7
+def versionBuildNumberMinor = 2
+def versionBuildNumberPatch = 0
 
 task printVersionName {
     doLast {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -40,7 +40,7 @@ tasks.withType(Test) {
     jacoco.excludes = ['jdk.internal.*']
 }
 
-def versionBuildNumberSequential = 36
+def versionBuildNumberSequential = 40
 
 def versionBuildNumberMajor = 1
 def versionBuildNumberMinor = 2

--- a/app/src/main/java/com/concordium/wallet/ui/cis2/lookfornew/TokenDetailsFragment.kt
+++ b/app/src/main/java/com/concordium/wallet/ui/cis2/lookfornew/TokenDetailsFragment.kt
@@ -68,7 +68,7 @@ class TokenDetailsFragment : TokensBaseFragment() {
                 setContractIndexAndSubIndex(token)
                 setDecimals(tokenMetadata)
                 setTicker(tokenMetadata)
-                showMatadata(tokenMetadata)
+                showMetadata(tokenMetadata)
             }
         }
     }
@@ -77,6 +77,9 @@ class TokenDetailsFragment : TokensBaseFragment() {
         if (tokenId.isNotBlank()) {
             binding.details.tokenIdHolder.visibility = View.VISIBLE
             binding.details.tokenId.text = tokenId
+        } else {
+            binding.details.tokenIdHolder.visibility = View.GONE
+            binding.details.tokenId.text = ""
         }
     }
 
@@ -89,6 +92,9 @@ class TokenDetailsFragment : TokensBaseFragment() {
         if (tokenMetadata.description.isNotBlank()) {
             binding.details.descriptionHolder.visibility = View.VISIBLE
             binding.details.description.text = tokenMetadata.description
+        } else {
+            binding.details.descriptionHolder.visibility = View.GONE
+            binding.details.description.text = ""
         }
     }
 
@@ -113,20 +119,21 @@ class TokenDetailsFragment : TokensBaseFragment() {
 
         if (tokenIndex.isNotBlank()) {
             binding.details.contractIndexHolder.visibility = View.VISIBLE
-            binding.details.contractIndex.text = token.contractIndex
             if (token.subIndex.isNotBlank()) {
                 val combinedInfo = "${tokenIndex}, ${token.subIndex}"
                 binding.details.contractIndex.text = combinedInfo
             } else {
                 binding.details.contractIndex.text = tokenIndex
             }
+        } else {
+            binding.details.contractIndexHolder.visibility = View.GONE
+            binding.details.contractIndex.text = ""
         }
     }
 
     private fun setImage(tokenMetadata: TokenMetadata) {
         if (!tokenMetadata.display?.url.isNullOrBlank()) {
             binding.details.imageHolder.visibility = View.VISIBLE
-
             Glide.with(this)
                 .load(tokenMetadata.display?.url)
                 .placeholder(R.drawable.ic_token_loading_image)
@@ -134,6 +141,9 @@ class TokenDetailsFragment : TokensBaseFragment() {
                 .fitCenter()
                 .error(R.drawable.ic_token_no_image)
                 .into(binding.details.image)
+        } else {
+            binding.details.imageHolder.visibility = View.GONE
+            binding.details.image.setImageResource(android.R.color.transparent)
         }
     }
 
@@ -141,6 +151,9 @@ class TokenDetailsFragment : TokensBaseFragment() {
         if (!tokenMetadata.symbol.isNullOrBlank()) {
             binding.details.tokenHolder.visibility = View.VISIBLE
             binding.details.token.text = tokenMetadata.symbol
+        } else {
+            binding.details.tokenHolder.visibility = View.GONE
+            binding.details.token.text = ""
         }
     }
 
@@ -148,10 +161,13 @@ class TokenDetailsFragment : TokensBaseFragment() {
         if (tokenMetadata.unique.not()) {
             binding.details.decimalsHolder.visibility = View.VISIBLE
             binding.details.decimals.text = tokenMetadata.decimals.toString()
+        } else {
+            binding.details.decimalsHolder.visibility = View.GONE
+            binding.details.decimals.text = ""
         }
     }
 
-    private fun showMatadata(tokenMetadata: TokenMetadata) {
+    private fun showMetadata(tokenMetadata: TokenMetadata) {
         binding.details.showRawMetadataHolder.setOnClickListener {
             val builder = AlertDialog.Builder(requireContext())
             builder.setMessage(JSONObject(Gson().toJson(tokenMetadata)).toString(4))


### PR DESCRIPTION
## Purpose
Fix an issue when adding tokens, the token details view could show some information from another token.

## Changes
- Correctly reload data when token details fragment is initialized (Note the _correct_ solution would be to refactor so that the fragment was destroyed when not shown, but that is not feasible to do quickly).
- Bumped version to 1.2.0 (as that will be the CIS-2 release version) and bumped the build number to stop getting the force update flag activated.
- Fixed a typo.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.