### PR TITLE
Fix CCD token balance including shielded amount

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Removed token thumbnail and added name in token details activity
 - transfer token flow now ends in the proper place
 - fixed issue where ID pub duplicated id error showed
+- incorrect CCD token balance if some amount is shielded
 
 ### Changed
 

--- a/app/src/main/java/com/concordium/wallet/ui/cis2/SendTokenViewModel.kt
+++ b/app/src/main/java/com/concordium/wallet/ui/cis2/SendTokenViewModel.kt
@@ -25,7 +25,6 @@ import com.concordium.wallet.data.model.AccountBalance
 import com.concordium.wallet.data.model.AccountData
 import com.concordium.wallet.data.model.AccountNonce
 import com.concordium.wallet.data.model.GlobalParamsWrapper
-import com.concordium.wallet.data.model.InputEncryptedAmount
 import com.concordium.wallet.data.model.SubmissionData
 import com.concordium.wallet.data.model.Token
 import com.concordium.wallet.data.model.TransactionOutcome
@@ -40,6 +39,7 @@ import com.concordium.wallet.ui.account.common.accountupdater.AccountUpdater
 import com.concordium.wallet.ui.common.BackendErrorHandler
 import com.concordium.wallet.util.DateTimeUtil
 import com.concordium.wallet.util.Log
+import com.concordium.wallet.util.TokenUtil
 import com.concordium.wallet.util.toBigInteger
 import com.concordium.wallet.util.toHex
 import kotlinx.coroutines.CoroutineScope
@@ -300,23 +300,7 @@ class SendTokenViewModel(application: Application) : AndroidViewModel(applicatio
         val accountRepository =
             AccountRepository(WalletDatabase.getDatabase(getApplication()).accountDao())
         val account = accountRepository.findByAddress(accountAddress)
-        val atDisposal =
-            account?.getAtDisposalWithoutStakedOrScheduled(account.totalUnshieldedBalance)
-                ?: BigInteger.ZERO
-        return Token(
-            "",
-            "CCD",
-            "",
-            null,
-            false,
-            "",
-            "",
-            true,
-            (account?.totalBalance ?: BigInteger.ZERO),
-            atDisposal,
-            "",
-            "CCD"
-        )
+        return TokenUtil.getCCDToken(account)
     }
 
     fun getCipherForBiometrics(): Cipher? {

--- a/app/src/main/java/com/concordium/wallet/util/TokenUtil.kt
+++ b/app/src/main/java/com/concordium/wallet/util/TokenUtil.kt
@@ -1,14 +1,32 @@
 package com.concordium.wallet.util
 
-import java.math.BigInteger
 import com.concordium.wallet.data.model.Token
 import com.concordium.wallet.data.room.Account
+import java.math.BigInteger
 
 
 object TokenUtil {
 
     fun getCCDToken(account: Account?): Token {
-        val atDisposal = account?.getAtDisposalWithoutStakedOrScheduled(account.totalBalance) ?: BigInteger.ZERO
-        return Token("", "CCD", "", null, false, "", "",true, (account?.totalBalance ?: BigInteger.ZERO), atDisposal, "", "CCD")
+        val totalUnshieldedBalance = account?.totalUnshieldedBalance
+            ?: BigInteger.ZERO
+        val atDisposal =
+            account?.getAtDisposalWithoutStakedOrScheduled(totalUnshieldedBalance)
+                ?: BigInteger.ZERO
+
+        return Token(
+            id = "",
+            token = "CCD",
+            totalSupply = "",
+            tokenMetadata = null,
+            isSelected = false,
+            contractIndex = "",
+            subIndex = "",
+            isCCDToken = true,
+            totalBalance = totalUnshieldedBalance,
+            atDisposal = atDisposal,
+            contractName = "",
+            symbol = "CCD"
+        )
     }
 }


### PR DESCRIPTION
## Purpose

This pull request fixes CCD token created by `TokenUtil` having incorrect at disposal balance if some amount is shielded on this account:
<p float="left">
<img width=320 src="https://github.com/Concordium/concordium-reference-wallet-android/assets/5675681/c44d2b5d-ff13-4d08-bf36-be9b802825df" />
<img width=320 src="https://github.com/Concordium/concordium-reference-wallet-android/assets/5675681/40305d2d-dc02-4407-95de-e020a8bfe95b" />
</p>

## Changes

- Fix CCD token balance including shielded amount
- Use `TokenUtil` to create CCD token in `SendTokenViewModel`

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.

## CLA acceptance

_Remove if not applicable.

By submitting the contribution I accept the terms and conditions of the
Contributor License Agreement v1.0
- link: https://developers.concordium.com/CLAs/Contributor-License-Agreement-v1.0.pdf

- [x] I accept the above linked CLA.
