### PR TITLE
[CBW-1035] fixed an when comparing 2 unsorted lists resulting in wrong message when managing tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Fixed
+- fixed an when comparing 2 unsorted lists resulting in wrong message when managing tokens
 
 ### Changed
 

--- a/app/src/main/java/com/concordium/wallet/ui/cis2/TokensViewModel.kt
+++ b/app/src/main/java/com/concordium/wallet/ui/cis2/TokensViewModel.kt
@@ -311,10 +311,11 @@ class TokensViewModel(application: Application) : AndroidViewModel(application) 
                     val unselectedTokenIds =
                         updatedTokens.filter { it.isSelected.not() }.map { it.token }
                     when {
-                        existingContractTokenIds
-                            .any { unselectedTokenIds.contains(it) } -> anyChanges = true
+                        existingContractTokenIds.any { unselectedTokenIds.contains(it) } ->
+                            anyChanges = true
 
-                        selectedTokens.map { it.token } != existingContractTokenIds ->
+                        selectedTokens.map { it.token }
+                            .containsAll(existingContractTokenIds).not() ->
                             anyChanges = true
                     }
 


### PR DESCRIPTION
## Changes

[CBW-1035] fixed an when comparing 2 unsorted lists resulting in wrong message when managing tokens
## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.

## CLA acceptance

_Remove if not applicable.

By submitting the contribution I accept the terms and conditions of the
Contributor License Agreement v1.0
- link: https://developers.concordium.com/CLAs/Contributor-License-Agreement-v1.0.pdf

- [x] I accept the above linked CLA.


[CBW-1035]: https://concordium.atlassian.net/browse/CBW-1035?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ