### PR TITLE
WalletConnect: Fix parsing of "broken" schema format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+
 - Changed application colours to align with new designs.
+
+### Fixed
+
+- WalletConnect: Fix parsing of "broken" schema format for contract update transactions.
 
 ## [1.3.0]
 

--- a/app/src/main/java/com/concordium/wallet/data/walletconnect/ParamsDeserializer.kt
+++ b/app/src/main/java/com/concordium/wallet/data/walletconnect/ParamsDeserializer.kt
@@ -1,9 +1,11 @@
 package com.concordium.wallet.data.walletconnect
 
+import android.util.Base64
 import com.google.gson.JsonDeserializationContext
 import com.google.gson.JsonDeserializer
 import com.google.gson.JsonElement
 import com.google.gson.JsonParseException
+import java.lang.IllegalArgumentException
 import java.lang.reflect.Type
 
 class ParamsDeserializer : JsonDeserializer<Params?> {
@@ -44,7 +46,7 @@ class ParamsDeserializer : JsonDeserializer<Params?> {
         if (schemaElement == null || schemaElement.isJsonNull) return null
 
         if (schemaElement.isJsonObject) {
-            return try {
+            try {
                 val schema: Schema.ValueSchema =
                     context.deserialize(schemaElement, Schema.ValueSchema::class.java)
                 if (schema.type == null || schema.value == null) {
@@ -53,7 +55,16 @@ class ParamsDeserializer : JsonDeserializer<Params?> {
                 return schema
             } catch (ex: JsonParseException) {
                 try {
-                    return context.deserialize(schemaElement, Schema.BrokenSchema::class.java)
+                    val schema: Schema.BrokenSchema =
+                        context.deserialize(schemaElement, Schema.BrokenSchema::class.java)
+                    val schemaType = when (schema.type) {
+                        "ModuleSchema" -> "module"
+                        "TypeSchema" -> "parameter"
+                        else -> throw IllegalArgumentException("invalid schema type '${schema.type}")
+                    }
+                    val schemaValueBytes = schema.value.data.map { it.toByte() }.toByteArray()
+                    val schemaValue = Base64.encodeToString(schemaValueBytes, Base64.NO_WRAP)
+                    return Schema.ValueSchema(type = schemaType, value = schemaValue)
                 } catch (ex: JsonParseException) {
                     return null
                 }


### PR DESCRIPTION
The format was emitted by mistake from the a previous version of the client side library `@concordium/wallet-connectors`. The library has been fixed but the wallets retain support for it for backwards compatibility.

The Wallet accepted the format but passed it indiscriminately to the crypto library without doing the appropriate conversion. This resulted in the library call failing without any error being surfaced to the user. Instead the parameters are just not presented on the approval screen. With this commit the conversion is performed right after the schema is parsed to handle it correctly. Ideally error handling should be improved to avoid misleading the user, but as the app is being deprecated, it may not be worth the effort.