### PR TITLE
Legacy tokenomics renaming

### DIFF
--- a/app/src/main/assets/baker_intro_flow_en_1.html
+++ b/app/src/main/assets/baker_intro_flow_en_1.html
@@ -10,7 +10,7 @@
 
 <body>
     <p>
-        A baker is a node that participates in the network by baking (creating) new blocks that are added to the chain. Each baker has a set of cryptographic keys called baker keys that the node needs to bake blocks. You generate the baker keys in the Mobile Wallet when you add a baker account. Once the baker node has been restarted with the baker keys, it will start baking two epochs after the transaction has been approved.
+        A validator is a node that participates in the network by producing (creating) new blocks that are added to the chain. Each validator has a set of cryptographic keys called validator keys that the node needs to produce blocks. You generate the validator keys in the Mobile Wallet when you add a validator account. Once the validator node has been restarted with the validator keys, it will start validation two epochs after the transaction has been approved.
     </p>
 </body>
 

--- a/app/src/main/assets/baker_intro_flow_en_2.html
+++ b/app/src/main/assets/baker_intro_flow_en_2.html
@@ -10,7 +10,7 @@
 
 <body>
     <p>
-        To become a baker you must run a node on the Concordium blockchain. Make sure that you have a setup where the node can operate around the clock. You can run the node yourself or use a third-party provider. Make sure your account in the Concordium Legacy Wallet has the required amount of CCD to become a baker.
+        To become a validator you must run a node on the Concordium blockchain. Make sure that you have a setup where the node can operate around the clock. You can run the node yourself or use a third-party provider. Make sure your account in the Concordium Legacy Wallet has the required amount of CCD to become a validator.
     </p>
 </body>
 

--- a/app/src/main/assets/baker_intro_flow_en_3.html
+++ b/app/src/main/assets/baker_intro_flow_en_3.html
@@ -10,7 +10,7 @@
 
 <body>
     <p>
-        You have the option when adding a baker to open a baker pool or not. A baker pool allows others who want to earn rewards to do so without the need to run a node or become a baker themselves. To do this they delegate an amount to your baker pool which then increases your total stake and your chances of winning the lottery to bake a block. At each pay day the rewards will be distributed to you and your delegators. You can also choose not to open a pool, in which case only your own stake applies toward the lottery. You can always open or close a pool later.
+        You have the option when adding a validator to open a staking pool or not. A staking pool allows others who want to earn rewards to do so without the need to run a node or become a validator themselves. To do this they delegate an amount to your staking pool which then increases your total stake and your chances of winning the lottery to produce a block. At each pay day the rewards will be distributed to you and your delegators. You can also choose not to open a pool, in which case only your own stake applies toward the lottery. You can always open or close a pool later.
     </p>
 </body>
 

--- a/app/src/main/assets/baker_remove_intro_flow_en_1.html
+++ b/app/src/main/assets/baker_remove_intro_flow_en_1.html
@@ -10,13 +10,13 @@
 
 <body>
     <p>
-        If you no longer wish to bake on an account, you can stop baking. There is a cool-down period, during which the staked amount for the baker will continue to bake and earn rewards. After the cool-down, the full stake amount will be unlocked on your public balance.
+        If you no longer wish to validate on an account, you can stop validation. There is a cool-down period, during which the staked amount for the validator will continue to validate and earn rewards. After the cool-down, the full stake amount will be unlocked on your public balance.
     </p>
     <p>
         If your pool has any delegators, they will be automatically moved to passive delegation, if they don’t decide to do something else.
     </p>
     <p>
-        If you deregister the baker, remember that this does not shut down your node. You must shut down the node in a separate action if you no longer wish to run a node on the Concordium blockchain.
+        If you deregister the validator, remember that this does not shut down your node. You must shut down the node in a separate action if you no longer wish to run a node on the Concordium blockchain.
     </p>
 </body>
 

--- a/app/src/main/assets/baker_update_intro_flow_en_1.html
+++ b/app/src/main/assets/baker_update_intro_flow_en_1.html
@@ -10,11 +10,11 @@
 
 <body>
     <p>
-        When you have registered a baker, you can make the following updates:
+        When you have registered a validator, you can make the following updates:
         <ul>
-            <li>Update baker stake</li>
+            <li>Update validator stake</li>
             <li>Update pool settings</li>
-            <li>Update baker keys</li>
+            <li>Update validator keys</li>
         </ul>
         This guide explains each of the different types of update. If you are already familiar with them, you can skip the guide below.
     </p>

--- a/app/src/main/assets/baker_update_intro_flow_en_2.html
+++ b/app/src/main/assets/baker_update_intro_flow_en_2.html
@@ -10,10 +10,10 @@
 
 <body>
     <p>
-        When updating your baker stake you can choose to increase or decrease your stake. If you increase your stake, this is most often effective from the next pay day. If the transaction occurs too close to the next pay day, the update will be effective from the following pay day.
+        When updating your validator stake you can choose to increase or decrease your stake. If you increase your stake, this is most often effective from the next pay day. If the transaction occurs too close to the next pay day, the update will be effective from the following pay day.
     </p>
     <p>
-        If you decrease your stake, there is a longer cool-down period. During the cool-down period, the staked amount continues to bake and earn rewards.
+        If you decrease your stake, there is a longer cool-down period. During the cool-down period, the staked amount continues to validate and earn rewards.
     </p>
     <p>
         You can also adjust whether you want rewards restaked or not. If the transaction is not made too close to the next pay day, it will take effect then; otherwise it will be effective at the next pay day over.

--- a/app/src/main/assets/baker_update_intro_flow_en_3.html
+++ b/app/src/main/assets/baker_update_intro_flow_en_3.html
@@ -15,7 +15,7 @@
     <p>
         Pool status:
         <ul style="margin-top: 0;">
-            <li>Open pool: open a pool for a previously closed baker</li>
+            <li>Open pool: open a pool for a previously closed validator</li>
             <li>Closed for new: close the pool to new delegators. Existing delegators are not affected.</li>
             <li>Close pool: close a pool for all delegators.</li>
         </ul>

--- a/app/src/main/assets/baker_update_intro_flow_en_4.html
+++ b/app/src/main/assets/baker_update_intro_flow_en_4.html
@@ -10,10 +10,10 @@
 
 <body>
     <p>
-        There is a cool-down period if you choose to close a pool. During this time, all delegators continue in the pool, and the pool continues to earn rewards if it bakes.
+        There is a cool-down period if you choose to close a pool. During this time, all delegators continue in the pool, and the pool continues to earn rewards if it validates.
     </p>
     <p>
-        After the cool-down, the delegators are removed and the pool will be closed. The baker will keep baking with your own stake afterwards.
+        After the cool-down, the delegators are removed and the pool will be closed. The validator will keep validating with your own stake afterwards.
     </p>
     <p>
         Changes to the metadata URL take effect from the next pay unless the transaction is made too close to the pay day. In that case, it will take effect from the next pay day over.

--- a/app/src/main/assets/baker_update_intro_flow_en_5.html
+++ b/app/src/main/assets/baker_update_intro_flow_en_5.html
@@ -10,7 +10,7 @@
 
 <body>
     <p>
-        If you believe your baker keys have been compromised or lost, you can generate and submit a new set of keys. It is important to remember to restart your node with the new set of keys after registering them on the chain. As the update takes effect on chain from the next pay day, it is preferable to restart the node with the new keys as close to the next pay day as possible to prevent the baker from having down time.</p>
+        If you believe your validator keys have been compromised or lost, you can generate and submit a new set of keys. It is important to remember to restart your node with the new set of keys after registering them on the chain. As the update takes effect on chain from the next pay day, it is preferable to restart the node with the new keys as close to the next pay day as possible to prevent the validator from having down time.</p>
 </body>
 
 </html>

--- a/app/src/main/assets/delegation_intro_flow_en_1.html
+++ b/app/src/main/assets/delegation_intro_flow_en_1.html
@@ -10,7 +10,7 @@
 
 <body>
     <p>
-        Delegation allows users on the Concordium blockchain to earn rewards without the need to become a baker or run a node.
+        Delegation allows users on the Concordium blockchain to earn rewards without the need to become a validator or run a node.
     </p>
     <p>
         By delegating some of your funds to a pool, you can earn rewards.

--- a/app/src/main/assets/delegation_intro_flow_en_2.html
+++ b/app/src/main/assets/delegation_intro_flow_en_2.html
@@ -17,10 +17,10 @@
         </ul>
     </p>
     <p>
-        A baker pool is managed by an individual baker running a node, so the rewards depend on that baker’s performance.
+        A staking pool is managed by an individual validator running a node, so the rewards depend on that validator’s performance.
     </p>
     <p>
-        Since passive delegation doesn’t go to a specific pool, it mitigates the risk of a single baker performing badly, however, rewards are lower.
+        Since passive delegation doesn’t go to a specific pool, it mitigates the risk of a single validator performing badly, however, rewards are lower.
     </p>
     <p>
         For more info visit<br /><b><a href="https://developer.concordium.software/en/mainnet/net/concepts/concepts-delegation.html">developer.concordium.software</a></b>

--- a/app/src/main/assets/delegation_intro_flow_en_3.html
+++ b/app/src/main/assets/delegation_intro_flow_en_3.html
@@ -10,19 +10,19 @@
 
 <body>
     <p>
-        A baker pool is managed by an individual baker.
+        A staking pool is managed by an individual validator.
     </p>
     <p>
-        Running a pool allows a baker to attract more stake and thus increase chances of being selected to bake a block.
+        Running a pool allows a validator to attract more stake and thus increase chances of being selected to produce a block.
     </p>
     <p>
-        Bakers also earn a commission from the delegators upon baking a block.
+        Validators also earn a commission from the delegators upon producing a block.
     </p>
     <p>
-        Delegating to a baker pool is usually more profitable than passive delegation, but there is also a risk of losing out on rewards if the baker is not running properly. It is therefore a good idea to keep an eye on the baker’s performance.
+        Delegating to a staking pool is usually more profitable than passive delegation, but there is also a risk of losing out on rewards if the validator is not running properly. It is therefore a good idea to keep an eye on the validator’s performance.
     </p>
     <p>
-        You can read more about how to investigate a baker’s performance on our <b><a href="https://developer.concordium.software/en/mainnet/net/concepts/concepts-delegation.html">documentation website</a></b>.
+        You can read more about how to investigate a validator’s performance on our <b><a href="https://developer.concordium.software/en/mainnet/net/concepts/concepts-delegation.html">documentation website</a></b>.
     </p>
 </body>
 

--- a/app/src/main/assets/delegation_intro_flow_en_4.html
+++ b/app/src/main/assets/delegation_intro_flow_en_4.html
@@ -13,10 +13,10 @@
         For CCD holders who do not want to regularly check the performance of a chosen pool, but just want a stable way of earning rewards, passive delegation offers a low-risk, low-reward alternative.
     </p>
     <p>
-        This staking strategy is not associated with a specific baker, so there is no risk of poor baker health.
+        This staking strategy is not associated with a specific validator, so there is no risk of poor validator health.
     </p>
     <p>
-        The trade-off when choosing passive delegation is that the return on your stake will be less than what you may receive, when delegating to a specific baker pool.
+        The trade-off when choosing passive delegation is that the return on your stake will be less than what you may receive, when delegating to a specific staking pool.
     </p>
 </body>
 

--- a/app/src/main/assets/delegation_intro_flow_en_5.html
+++ b/app/src/main/assets/delegation_intro_flow_en_5.html
@@ -10,7 +10,7 @@
 
 <body>
     <p>
-        Whether you choose an individual baking pool or passive delegation, rewards are paid out at what is called the pay day. Rewards are distributed to everyone in the pool proportional to their stake, and a commission is paid to the baker by all delegators.
+        Whether you choose an individual staking pool or passive delegation, rewards are paid out at what is called the pay day. Rewards are distributed to everyone in the pool proportional to their stake, and a commission is paid to the validator by all delegators.
     </p>
     <p>
         If you make updates to your delegation at a later point, most of these will also take effect from the next pay day.

--- a/app/src/main/assets/delegation_remove_flow_en_2.html
+++ b/app/src/main/assets/delegation_remove_flow_en_2.html
@@ -12,7 +12,7 @@
     Only the delegation amount is locked during the cool-down period.
     </p>
     <p>
-    This means that you can still change restake status and target baker pool during the cool-down.
+    This means that you can still change restake status and target staking pool during the cool-down.
     </p>
 </body>
 

--- a/app/src/main/assets/delegation_update_flow_en_2.html
+++ b/app/src/main/assets/delegation_update_flow_en_2.html
@@ -9,7 +9,7 @@
 
 <body>
     <p>
-    If you increase your delegation amount, change your target baker pool, or change whether you want to restake your rewards or not, these changes will take effect from the next pay day.
+    If you increase your delegation amount, change your target staking pool, or change whether you want to restake your rewards or not, these changes will take effect from the next pay day.
     </p>
     <p>
     This will typically be within a period of 24 hours, but in some cases it can take up to 25 hours.

--- a/app/src/main/java/com/concordium/wallet/ui/bakerdelegation/common/DelegationBakerViewModel.kt
+++ b/app/src/main/java/com/concordium/wallet/ui/bakerdelegation/common/DelegationBakerViewModel.kt
@@ -54,7 +54,7 @@ class DelegationBakerViewModel(application: Application) : AndroidViewModel(appl
     private var transferSubmissionStatusRequest: BackendRequest<TransferSubmissionStatus>? = null
 
     companion object {
-        const val FILE_NAME_BAKER_KEYS = "baker-credentials.json"
+        const val FILE_NAME_BAKER_KEYS = "validator-credentials.json"
         const val EXTRA_DELEGATION_BAKER_DATA = "EXTRA_DELEGATION_BAKER_DATA"
         const val AMOUNT_TOO_LARGE_FOR_POOL = -100
         const val AMOUNT_TOO_LARGE_FOR_POOL_COOLDOWN = -200

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -67,7 +67,7 @@
     <!-- AccountView -->
     <string name="view_account_initial">Initial</string>
     <string name="view_account_read_only">Read-only</string>
-    <string name="view_account_baking">Baking</string>
+    <string name="view_account_baking">Validation</string>
     <string name="view_account_delegating">Delegating</string>
     <string name="view_account_name_container">(%1$s)</string>
 
@@ -133,12 +133,12 @@
 <p>You are solely responsible for safekeeping your passwords, PINs, account keys, encryption keys, identity, and any other codes you use to access the Concordium Legacy Wallet or any information, CCD, or voucher. If you lose access to the Concordium Legacy Wallet, private keys, or identity, and you have not separately stored a backup of your accounts and the corresponding password(s), you acknowledge and agree that any tokens you have associated with that account will become inaccessible.</p>
 <p>Please note: If you have chosen to use assistants based on speech recognition (e.g., Siri) or patterns of use, this means that information about your use of Concordium Legacy Wallet, including recipients, amounts, and messages, is sent to the provider of the assistant. Your own use of any assistant determines what information is sent. Concordium Legacy Wallet does not send any information.</p>
 
-<h1>Baking and Delegation</h1>
-<p>Node runners are awarded CCD for running nodes on the Concordium blockchain through a process called baking. Other CCD holders can be rewarded for supporting this process through delegation. The Concordium Legacy Wallet supports management of baking and delegation. Each account can only have one baking or delegation process active at any given time.</p>
-<p>While engaged in baking or delegation, the allocated CCD will remain in the account in a locked form. Termination of baking and delegation activates a cool-down period, where baking and delegation is still active, however, the CCDs will not be available in the wallet until the cool-down period is over. Read more about baking and delegation on developer.concordium.software</p>
-<p>When activating, managing and terminating baking and delegation blockchain transaction fees apply. You should always ensure you have sufficient CCD in your available balance to cover these fees.</p>
-<p>When activating baking and delegation from the Concordium Legacy Wallet you acknowledge and understand how these features work and that historic performance is not a guarantee for future performance.</p>
-<p>Concordium Software does not assume any responsibility for the amount of rewards generated from baking and delegation.</p>
+<h1>Validation and Delegation</h1>
+<p>Node runners are awarded CCD for running nodes on the Concordium blockchain through a process called validation. Other CCD holders can be rewarded for supporting this process through delegation. The Concordium Wallet for Mobile supports management of validation and delegation. Each account can only have one validation or delegation process active at any given time.</p>
+<p>While engaged in validation or delegation, the allocated CCD will remain in the account in a locked form. Termination of validation and delegation activates a cool-down period, where validation and delegation is still active, however, the CCDs will not be available in the wallet until the cool-down period is over. Read more about validation and delegation on developer.concordium.software</p>
+<p>When activating, managing and terminating validation and delegation blockchain transaction fees apply. You should always ensure you have sufficient CCD in your available balance to cover these fees.</p>
+<p>When activating validation and delegation from the Concordium Wallet for Mobile you acknowledge and understand how these features work and that historic performance is not a guarantee for future performance.</p>
+<p>Concordium Software does not assume any responsibility for the amount of rewards generated from validation and delegation.   </p>
 
 <h1>Term</h1>
 <p>This agreement will apply between you and Concordium Software from your download of the Concordium Legacy Wallet, and until you have completely removed the Concordium Legacy Wallet in its entirety from your device.</p>
@@ -216,7 +216,7 @@
     <string name="delegation_intro_flow_title">Delegation</string>
     <string name="delegation_intro_subtitle1">Delegation</string>
     <string name="delegation_intro_subtitle2">Delegation models</string>
-    <string name="delegation_intro_subtitle3">Baker pools</string>
+    <string name="delegation_intro_subtitle3">Staking pools</string>
     <string name="delegation_intro_subtitle4">Passive delegation</string>
     <string name="delegation_intro_subtitle5">Pay days</string>
     <string name="delegation_intro_subtitle6">Lock-in and cool-downs</string>
@@ -241,7 +241,7 @@
     <string name="delegation_status_waiting_to_finalize">Waiting for transaction to finalize</string>
     <string name="delegation_status_new_amount">New delegation amount</string>
     <string name="delegation_status_effective_time">%1$s at %2$s</string>
-    <string name="delegation_status_pool_deregistered">This pool has been deregistered, and will stop baking on</string>
+    <string name="delegation_status_pool_deregistered">This pool has been deregistered, and will stop validation on</string>
 
     <string name="delegation_register_delegation_title">Register delegation</string>
     <string name="delegation_update_delegation_title">Update delegation</string>
@@ -257,19 +257,19 @@
     <string name="delegation_status_content_delegation_will_be_stopped">The delegation will be stopped, and the delegation amount will be unlocked on the public balance of the account.</string>
 
     <string name="delegation_register_delegation_intro">You can delegate to an open pool of your choice, or you can stake using passive delegation.</string>
-    <string name="delegation_register_delegation_desc">If you don’t already know what baker pool you want to delegate an amount to, you can read more about finding one here:\n\n<a href="https://developer.concordium.software/en/mainnet/net/concepts/concepts-delegation.html">developer.concordium.software</a></string>
-    <string name="delegation_register_delegation_desc_passive">Passive delegation is an alternative to delegation to a specific baker pool that has lower rewards. With passive delegation you do not have to worry about the uptime or quality of a baker node.\n\nFor more info you can visit\n\n<a href="https://developer.concordium.software/en/mainnet/net/concepts/concepts-delegation.html">developer.concordium.software</a></string>
-    <string name="delegation_register_delegation_pool_id_hint">Enter baker pool ID</string>
-    <string name="delegation_register_delegation_pool_id_hint_update">Optional: New baker pool ID</string>
-    <string name="delegation_update_delegation_pool_id_baker">Current target: Baker id %1$s</string>
+    <string name="delegation_register_delegation_desc">If you don\'t already know which staking pool you want to delegate an amount to, you can look for one here:\n\n<a href="https://ccdscan.io/staking">https://ccdscan.io/staking</a></string>
+    <string name="delegation_register_delegation_desc_passive">Passive delegation is an alternative to delegation to a specific staking pool that has lower rewards. With passive delegation you do not have to worry about the uptime or quality of a validator node.\n\nFor more info you can visit\n\n<a href="https://developer.concordium.software/en/mainnet/net/concepts/concepts-delegation.html">developer.concordium.software</a></string>
+    <string name="delegation_register_delegation_pool_id_hint">Enter staking pool ID</string>
+    <string name="delegation_register_delegation_pool_id_hint_update">Optional: New staking pool ID</string>
+    <string name="delegation_update_delegation_pool_id_baker">Current target: Validator id %1$s</string>
     <string name="delegation_update_delegation_pool_id__passive">Current target: Passive </string>
 
-    <string name="delegation_register_delegation_pool_baker">Baker</string>
+    <string name="delegation_register_delegation_pool_baker">Validator</string>
     <string name="delegation_register_delegation_passive">Passive</string>
     <string name="delegation_register_delegation_passive_long">Passive delegation</string>
     <string name="delegation_register_delegation_continue">Continue</string>
 
-    <string name="delegation_register_delegation_pool_id_error">Invalid target baker pool ID</string>
+    <string name="delegation_register_delegation_pool_id_error">Invalid target staking pool ID</string>
     <string name="delegation_register_delegation_pool_id_closed">This pool is closed</string>
 
     <string name="delegation_register_delegation_yes_restake">Yes, restake</string>
@@ -362,19 +362,19 @@
     <string name="delegation_amount_too_large_while_in_cooldown">Your delegation amount is too large for this pool.</string>
 
 
-    <!-- Baker intro -->
-    <string name="baker_intro_flow_title">Become a baker</string>
-    <string name="baker_intro_subtitle1">Become a baker</string>
+    <!-- Validator intro -->
+    <string name="baker_intro_flow_title">Become a validator</string>
+    <string name="baker_intro_subtitle1">Become a validator</string>
     <string name="baker_intro_subtitle2">The node</string>
     <string name="baker_intro_subtitle3">Opening a pool</string>
 
-    <string name="baker_registration_title">Register baker</string>
-    <string name="baker_registration_explain">You have the option to open your baker as a pool for others to delegate their CCD to.\n\nIf you choose to open your pool, other people will be able to delegate CCDs to your baking pool.\n\nYou can also keep the pool closed, if you want only your own CCDs to be staked.</string>
+    <string name="baker_registration_title">Register validator</string>
+    <string name="baker_registration_explain">You have the option to open your validator as a pool for others to delegate their CCD to.\n\nIf you choose to open your pool, other people will be able to delegate CCDs to your staking pool.\n\nYou can also keep the pool closed, if you want only your own CCDs to be staked.</string>
     <string name="baker_registration_open">Open for delegation</string>
     <string name="baker_registration_close">Close for delegation</string>
     <string name="baker_registration_continue">Continue</string>
-    <string name="baker_registration_export">Export baker keys</string>
-    <string name="baker_registration_export_explain">Your new baker keys have been generated. Before you can continue, you must export and save them. The keys will have to be added to the baker node.\n\nNOTICE: Besides exporting the keys, you will have to finish and submit the transaction afterwards for the baker to be registered.</string>
+    <string name="baker_registration_export">Export validator keys</string>
+    <string name="baker_registration_export_explain">Your new validator keys have been generated. Before you can continue, you must export and save them. The keys will have to be added to the validator node.\n\nNOTICE: Besides exporting the keys, you will have to finish and submit the transaction afterwards for the validator to be registered.</string>
     <string name="baker_registration_export_election_verify_key">Election verify key</string>
     <string name="baker_registration_export_signature_verify_key">Signature verify key</string>
     <string name="baker_registration_export_aggregation_verify_key">Aggregation verify key</string>
@@ -382,23 +382,23 @@
     <string name="baker_registration_export_notice_message">This is your only chance to export and save the keys.\n\nThey cannot be recreated, so you will have to generate new keys and register them with a transaction, if you lose these.</string>
     <string name="baker_registration_export_notice_ok">OK</string>
 
-    <string name="baker_registration_open_title">Add baker</string>
-    <string name="baker_registration_open_explain">You can choose to add a URL with metadata about your baker. Leave it blank if you don’t have any.\n\nYou can read more about the metadata URL on\n\n<a href="https://developer.concordium.software">developer.concordium.software</a></string>
+    <string name="baker_registration_open_title">Add validator</string>
+    <string name="baker_registration_open_explain">You can choose to add a URL with metadata about your validator. Leave it blank if you don’t have any.\n\nYou can read more about the metadata URL on\n\n<a href="https://developer.concordium.software">developer.concordium.software</a></string>
     <string name="baker_registration_open_continue">Continue</string>
     <string name="baker_registration_open_url_hint">Paste your metadata URL here</string>
 
-    <string name="baker_status_title">Baker status</string>
-    <string name="baker_status_register_baker">Register baker</string>
-    <string name="baker_status_no_baker_title">This account has no baker registered.</string>
-    <string name="baker_status_no_baker">This account has no baker registered. You can register a baker with the button below.</string>
-    <string name="baker_status_update_baker_settings">Update baker settings</string>
-    <string name="baker_status_baker_waiting_title">Waiting for baker transaction to finalize.</string>
+    <string name="baker_status_title">Validator status</string>
+    <string name="baker_status_register_baker">Register validator</string>
+    <string name="baker_status_no_baker_title">This account has no validator registered.</string>
+    <string name="baker_status_no_baker">This account has no validator registered. You can register a validator with the button below.</string>
+    <string name="baker_status_update_baker_settings">Update validator settings</string>
+    <string name="baker_status_baker_waiting_title">Waiting for validator transaction to finalize.</string>
     <string name="baker_status_baker_waiting">Waiting for transaction to finalize.</string>
-    <string name="baker_status_baker_registered_title">Your baker is registered.</string>
-    <string name="baker_status_baker_remove">Remove baker</string>
-    <string name="baker_status_baker_account">Baker account</string>
-    <string name="baker_status_baker_stake">Baker stake</string>
-    <string name="baker_status_baker_id">Baker ID</string>
+    <string name="baker_status_baker_registered_title">Your validator is registered.</string>
+    <string name="baker_status_baker_account">Validator account</string>
+    <string name="baker_status_baker_remove">Remove validator</string>
+    <string name="baker_status_baker_stake">Validator stake</string>
+    <string name="baker_status_baker_id">Validator ID</string>
     <string name="baker_status_baker_rewards_will_be">Rewards will be</string>
     <string name="baker_status_baker_added_to_stake">Added to stake</string>
     <string name="baker_status_baker_at_disposal">Added to disposable amount</string>
@@ -411,30 +411,30 @@
         <item quantity="one">The following changes will take effect in approximately %d day</item>
         <item quantity="other">The following changes will take effect in approximately %d days</item>
     </plurals>
-    <string name="baker_status_baker_effective_remove">The baker will be deregistered, and the stake will be unlocked on the public balance of the account.</string>
+    <string name="baker_status_baker_effective_remove">The validator will be deregistered, and the stake will be unlocked on the public balance of the account.</string>
     <string name="baker_status_baker_effective_time">%1$s at %2$s</string>
     <string name="baker_status_baker_take_effect_on">The following changes will take effect on</string>
-    <string name="baker_status_baker_stake_lowered_to">Baker stake will be lowered to</string>
+    <string name="baker_status_baker_stake_lowered_to">Validator stake will be lowered to</string>
 
-    <string name="baker_registration_amount_title">Register baker</string>
-    <string name="baker_registration_amount_explain">Do you want to automatically add your baking rewards to your baker stake?\n\nIf you choose to not restake your rewards, the amounts will be at disposal on your account balance at each pay day.</string>
-    <string name="baker_registration_amount_current_stake_title">Baker stake:</string>
+    <string name="baker_registration_amount_title">Register validator</string>
+    <string name="baker_registration_amount_explain">Do you want to automatically add your rewards to your validator stake?\n\nIf you choose to not restake your rewards, the amounts will be at disposal on your account balance at each pay day.</string>
+    <string name="baker_registration_amount_current_stake_title">Validator stake:</string>
     <string name="baker_registration_amount_enter_stake_title">Enter the amount you want to stake</string>
 
-    <string name="baker_registration_update_amount_title">Update baker stake</string>
+    <string name="baker_registration_update_amount_title">Update validator stake</string>
     <string name="baker_more_than_95_title">Warning</string>
-    <string name="baker_more_than_95_message">You are about to lock more than 95% of your total balance in a baker stake.\n\nIf you don’t have enough unlocked CCD at your disposal, you might not be able to pay future transaction fees.</string>
+    <string name="baker_more_than_95_message">You are about to lock more than 95% of your total balance in a validator stake.\n\nIf you don’t have enough unlocked CCD at your disposal, you might not be able to pay future transaction fees.</string>
     <string name="baker_more_than_95_continue">Continue</string>
-    <string name="baker_more_than_95_new_stake">Enter new baker stake</string>
+    <string name="baker_more_than_95_new_stake">Enter new validator stake</string>
     <string name="baker_registration_update_amount_estimated_transaction_fee_range">Estimated transaction fee:\nϾ%1$s - Ͼ%2$s</string>
     <string name="baker_registration_update_amount_estimated_transaction_fee_single">Estimated transaction fee:\nϾ%1$s</string>
-    <string name="baker_update_enter_new_stake">Enter your new total baker stake</string>
+    <string name="baker_update_enter_new_stake">Enter your new total validator stake</string>
 
-    <string name="baker_registration_confirmation_title">Register baker</string>
-    <string name="baker_registration_confirmation_explain">You are about to submit a register baker transaction that locks some of your funds in a stake. If you want to unlock the stake again, there will be a cool-down period.</string>
-    <string name="baker_register_confirmation_receipt_title">Transaction: Register baker</string>
-    <string name="baker_register_confirmation_receipt_account_to_bake_from">Account to register as baker</string>
-    <string name="baker_register_confirmation_receipt_amount_to_bake">Baker stake</string>
+    <string name="baker_registration_confirmation_title">Register validator</string>
+    <string name="baker_registration_confirmation_explain">You are about to submit a register validator transaction that locks some of your funds in a stake. If you want to unlock the stake again, there will be a cool-down period.</string>
+    <string name="baker_register_confirmation_receipt_title">Transaction: Register validator</string>
+    <string name="baker_register_confirmation_receipt_account_to_bake_from">Account to register as validator</string>
+    <string name="baker_register_confirmation_receipt_amount_to_bake">Validator stake</string>
     <string name="baker_register_confirmation_receipt_rewards_will_be">Rewards will be</string>
     <string name="baker_register_confirmation_receipt_pool_status">Delegation pool status</string>
     <string name="baker_register_confirmation_receipt_pool_status_open">Open for delegation</string>
@@ -447,39 +447,39 @@
     <string name="baker_register_confirmation_receipt_added_to_delegation_amount">Added to stake</string>
     <string name="baker_register_confirmation_receipt_at_disposal">Added to disposable amount</string>
     <string name="baker_register_confirmation_receipt_meta_data_url">Metadata URL</string>
-    <string name="baker_register_transaction_failed">Your baking transaction failed:\n\n%1$s\n\nDo you want to try again?</string>
-    <string name="baker_registration_confirmation_remove_title">Stop baking</string>
-    <string name="baker_registration_confirmation_remove_are_you_sure">Are you sure you want to make the following transaction to stop baking?</string>
-    <string name="baker_registration_confirmation_remove_transaction">Transaction: Stop baking</string>
-    <string name="baker_registration_confirmation_remove_account_to_stop">Account to stop baking</string>
-    <string name="baker_registration_confirmation_submit">Submit baker transaction</string>
-    <string name="baker_registration_confirmation_update_keys_title">Update baker keys</string>
+    <string name="baker_register_transaction_failed">Your validation transaction failed:\n\n%1$s\n\nDo you want to try again?</string>
+    <string name="baker_registration_confirmation_remove_title">Stop validation</string>
+    <string name="baker_registration_confirmation_remove_are_you_sure">Are you sure you want to make the following transaction to stop validation?</string>
+    <string name="baker_registration_confirmation_remove_transaction">Transaction: Stop validation</string>
+    <string name="baker_registration_confirmation_remove_account_to_stop">Account to stop validation</string>
+    <string name="baker_registration_confirmation_submit">Submit validator transaction</string>
+    <string name="baker_registration_confirmation_update_keys_title">Update validator keys</string>
     <string name="baker_registration_confirmation_update_pool_title">Update pool settings</string>
-    <string name="baker_registration_confirmation_update_stake_title">Update baker stake</string>
-    <string name="baker_registration_confirmation_update_keys_transaction_title">Transaction: Update baker keys</string>
+    <string name="baker_registration_confirmation_update_stake_title">Update validator stake</string>
+    <string name="baker_registration_confirmation_update_keys_transaction_title">Transaction: Update validator keys</string>
     <string name="baker_registration_confirmation_update_pool_transaction_title">Transaction: Update pool settings</string>
-    <string name="baker_registration_confirmation_update_stake_transaction_title">Transaction: Update baker stake</string>
-    <string name="baker_registration_confirmation_update_affected_account">Affected baker account</string>
-    <string name="baker_registration_confirmation_update_stake_update">Account to make baker update</string>
-    <string name="baker_registration_confirmation_update_stake_update_decrease_explain">You are about to submit a transaction that lowers your baker stake. Lowering your stake has a cool-down period, meaning it will not take effect immediately.\n\nThe baker cannot be removed and the stake cannot be changed until the cool-down is over.</string>
+    <string name="baker_registration_confirmation_update_stake_transaction_title">Transaction: Update validator stake</string>
+    <string name="baker_registration_confirmation_update_affected_account">Affected validator account</string>
+    <string name="baker_registration_confirmation_update_stake_update">Account to make validator update</string>
+    <string name="baker_registration_confirmation_update_stake_update_decrease_explain">You are about to submit a transaction that lowers your validator stake. Lowering your stake has a cool-down period, meaning it will not take effect immediately.\n\nThe validator cannot be removed and the stake cannot be changed until the cool-down is over.</string>
 
-    <string name="baker_update_intro_flow_title">Baking</string>
-    <string name="baker_update_intro_subtitle1">Updating baker settings</string>
-    <string name="baker_update_intro_subtitle2">Update baker stake</string>
+    <string name="baker_update_intro_flow_title">Validation</string>
+    <string name="baker_update_intro_subtitle1">Updating validator settings</string>
+    <string name="baker_update_intro_subtitle2">Update validator stake</string>
     <string name="baker_update_intro_subtitle3">Update pool settings (1/2)</string>
     <string name="baker_update_intro_subtitle4">Update pool settings (2/2)</string>
-    <string name="baker_update_intro_subtitle5">Update baker keys</string>
+    <string name="baker_update_intro_subtitle5">Update validator keys</string>
 
-    <string name="baker_remove_intro_flow_title">Baking</string>
-    <string name="baker_remove_intro_subtitle1">Stop baking</string>
+    <string name="baker_remove_intro_flow_title">Validation</string>
+    <string name="baker_remove_intro_subtitle1">Stop validation</string>
 
-    <string name="update_baker_settings_menu_update_baker_stake">Update baker stake</string>
+    <string name="update_baker_settings_menu_update_baker_stake">Update validator stake</string>
     <string name="update_baker_settings_menu_update_pool_settings">Update pool settings</string>
-    <string name="update_baker_settings_menu_update_baker_keys">Update baker keys</string>
-    <string name="update_baker_settings_menu_stop_baking">Stop baking</string>
+    <string name="update_baker_settings_menu_update_baker_keys">Update validator keys</string>
+    <string name="update_baker_settings_menu_stop_baking">Stop validation</string>
 
     <string name="baker_update_pool_settings_title">Update pool settings</string>
-    <string name="baker_update_pool_settings_explain">You have the option to open your baker as a pool for others to delegate their CCD to.\n\nIf you choose to open your pool, other people will be able to delegate CCDs to your baking pool.\n\nIf your pool is already open, you can also close it for new delegators, or you can close it for delegation completely.</string>
+    <string name="baker_update_pool_settings_explain">You have the option to open your validator as a pool for others to delegate their CCD to.\n\nIf you choose to open your pool, other people will be able to delegate CCDs to your staking pool.\n\nIf your pool is already open, you can also close it for new delegators, or you can close it for delegation completely.</string>
     <string name="baker_update_pool_settings_current_status_open">Current status: Open</string>
     <string name="baker_update_pool_settings_current_status_closed">Current status: Closed</string>
     <string name="baker_update_pool_settings_current_status_closed_for_new">Current status: Closed for new</string>
@@ -492,23 +492,21 @@
     <string name="baker_update_pool_settings_url_removed">Metadata URL removed</string>
 
     <string name="baker_notice_title">Notice</string>
-    <string name="baker_notice_message">Once your transaction has successfully finalized, the baker registration will take effect from the next pay day.\n\nRemember to restart your node with the baker keys.</string>
-    <string name="baker_notice_message_update_increase">Once your transaction has successfully finalized, the baker update will take effect from the next pay day.</string>
+    <string name="baker_notice_message">Once your transaction has successfully finalized, the validator registration will take effect from the next pay day.\n\nRemember to restart your node with the validator keys.</string>
+    <string name="baker_notice_message_update_increase">Once your transaction has successfully finalized, the validator update will take effect from the next pay day.</string>
     <plurals name="baker_notice_message_update_decrease">
-        <item quantity="one">Your decrease of the baker stake will take effect at the next pay day after a cool-down of %d day.\n\nOnce the transaction has finalized, you can see the time of the release on the baker status screen.</item>
-        <item quantity="other">Your decrease of the baker stake will take effect at the next pay day after a cool-down of %d days.\n\nOnce the transaction has finalized, you can see the time of the release on the baker status screen.</item>
+        <item quantity="one">Your decrease of the validator stake will take effect at the next pay day after a cool-down of %d day.\n\nOnce the transaction has finalized, you can see the time of the release on the validator status screen.</item>
+        <item quantity="other">Your decrease of the validator stake will take effect at the next pay day after a cool-down of %d days.\n\nOnce the transaction has finalized, you can see the time of the release on the validator status screen.</item>
     </plurals>
     <string name="baker_notice_message_update_pool">Once your transaction has successfully finalized, the pool settings update will take effect from the next pay day.</string>
-    <string name="baker_notice_message_update_keys">Once your transaction has successfully finalized, the new baker keys will take effect from the next pay day.\n\nThis means the node should be restarted with the new keys, as close to the next pay day as possible.</string>
+    <string name="baker_notice_message_update_keys">Once your transaction has successfully finalized, the new validator keys will take effect from the next pay day.\n\nThis means the node should be restarted with the new keys, as close to the next pay day as possible.</string>
     <plurals name="baker_notice_message_remove">
-        <item quantity="one">Your baker will stop at the next pay day after a cool-down of %d day.\n\nOnce the transaction has finalized, you can see the estimated time on the baker status screen.</item>
-        <item quantity="other">Your baker will stop at the next pay day after a cool-down of %d days.\n\nOnce the transaction has finalized, you can see the estimated time on the baker status screen.</item>
+        <item quantity="one">Your validator will stop at the next pay day after a cool-down of %d day.\n\nOnce the transaction has finalized, you can see the estimated time on the validator status screen.</item>
+        <item quantity="other">Your validator will stop at the next pay day after a cool-down of %d days.\n\nOnce the transaction has finalized, you can see the estimated time on the validator status screen.</item>
     </plurals>
     <string name="baker_notice_ok">Okay</string>
 
-    <string name="baker_update_keys_settings_title">Update baker keys</string>
-
-
+    <string name="baker_update_keys_settings_title">Update validator keys</string>
     <!-- ***** Auth ***** -->
 
     <!-- Auth -->
@@ -723,8 +721,7 @@
     <string name="account_details_gtu_drop_button">Request 2000CCD</string>
     <string name="account_details_shielded_transaction_fee">Shielded transaction fee</string>
     <string name="account_delegation_pending">Configure delegation</string>
-    <string name="account_baking_pending">Configure baker</string>
-
+    <string name="account_baking_pending">Configure validator</string>
     <string name="account_details_empty_identity_data">This account has no identity data revealed.</string>
 
 
@@ -950,8 +947,8 @@
     <string name="error_database_close">Close</string>
 
     <string name="accounts_overview_total_details_disposal">Total currently at disposal</string>
-    <string name="accounts_overview_total_details_staked">Stake with baker %1$d</string>
-    <string name="accounts_overview_total_details_staked_no_id">Stake with baker</string>
+    <string name="accounts_overview_total_details_staked">Stake with validator %1$d</string>
+    <string name="accounts_overview_total_details_staked_no_id">Stake with validator</string>
     <string name="account_details_menu_release_schedule">Release schedule</string>
     <string name="account_details_menu_transfer_filter">Transfer filters</string>
     <string name="account_details_menu_delegation">Delegation</string>
@@ -959,9 +956,9 @@
     <string name="account_details_menu_show_shielded">Show shielded balance on %1$s</string>
     <string name="account_details_menu_hide_shielded">Hide shielded balance on %1$s</string>
     <string name="account_details_menu_decrypt">Decrypt</string>
-    <string name="account_details_delegation_with_baker_pool">Delegation with baker pool %1$s</string>
+    <string name="account_details_delegation_with_baker_pool">Delegation with staking pool %1$s</string>
     <string name="account_details_delegation_with_passive_pool">Passive delegation</string>
-    <string name="account_details_stake_with_baker">Stake with baker %1$s</string>
+    <string name="account_details_stake_with_baker">Stake with validator %1$s</string>
 
     <string name="account_details_toggle_shielded">Shielded balance</string>
     <string name="account_details_toggle_balance">Balance</string>


### PR DESCRIPTION
## Purpose

Tokenomics renaming

## Changes

- Baker/baking renamed to validator/validation in UI.
- Default name for key file is now validator-credentials.json.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.

