### PR TITLE
More lenient CIS-2 Lookup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed:
+
+- Inability to add CIS-2 tokens with corrupted metadata or missing balance
+
 ## [1.5.0]
 
 ### Changed

--- a/app/src/main/java/com/concordium/wallet/ui/cis2/TokensAddAdapter.kt
+++ b/app/src/main/java/com/concordium/wallet/ui/cis2/TokensAddAdapter.kt
@@ -70,7 +70,8 @@ class TokensAddAdapter(
             }
         } ?: holder.binding.tokenIcon.setImageResource(R.drawable.ic_token_no_image)
 
-        holder.binding.title.text = tokenMetadata?.name ?: String.Empty
+        holder.binding.title.text =
+            tokenMetadata?.name ?: context.getString(R.string.cis_loading_metadata_progress)
 
         val tokenBalance = CurrencyUtil.formatGTU(
             token.totalBalance,

--- a/app/src/main/java/com/concordium/wallet/ui/cis2/TokensAddAdapter.kt
+++ b/app/src/main/java/com/concordium/wallet/ui/cis2/TokensAddAdapter.kt
@@ -2,8 +2,8 @@ package com.concordium.wallet.ui.cis2
 
 import android.content.Context
 import android.view.LayoutInflater
-import android.view.View
 import android.view.ViewGroup
+import androidx.core.view.isVisible
 import androidx.recyclerview.widget.RecyclerView
 import com.bumptech.glide.Glide
 import com.concordium.wallet.R
@@ -81,11 +81,9 @@ class TokensAddAdapter(
         holder.binding.subTitle.text =
             context.getString(R.string.cis_search_balance, tokenBalance)
 
-        if (showCheckBox) {
-            holder.binding.selection.isChecked = token.isSelected
-        } else {
-            holder.binding.selection.visibility = View.GONE
-        }
+        // Only allow selection when the metadata is loaded.
+        holder.binding.selection.isVisible = showCheckBox && token.tokenMetadata != null
+        holder.binding.selection.isChecked = token.isSelected
 
         holder.binding.root.setOnClickListener {
             tokenClickListener?.onRowClick(token)

--- a/app/src/main/java/com/concordium/wallet/ui/cis2/TokensViewModel.kt
+++ b/app/src/main/java/com/concordium/wallet/ui/cis2/TokensViewModel.kt
@@ -152,14 +152,19 @@ class TokensViewModel(application: Application) : AndroidViewModel(application) 
                         token.contractIndex = tokenData.contractIndex
                         token.subIndex = tokenData.subIndex
                     }
-                    tokens.addAll(cis2Tokens.tokens)
-                    if (cis2Tokens.tokens.isEmpty()) {
+
+                    // Do not add burnt tokens (total supply 0).
+                    val filteredCis2Tokens = cis2Tokens.tokens
+                        .filter { it.totalSupply != "0" }
+
+                    tokens.addAll(filteredCis2Tokens)
+                    if (filteredCis2Tokens.isEmpty()) {
                         lookForTokens.postValue(TOKENS_EMPTY)
                         allowToLoadMore = true
                         contactAddressLoading.postValue(false)
                     } else {
                         CoroutineScope(Dispatchers.IO).launch {
-                            val metadata = async { loadTokensMetadataUrls(cis2Tokens.tokens) }
+                            val metadata = async { loadTokensMetadataUrls(filteredCis2Tokens) }
                             loadTokensBalances()
                             val isSuccess = metadata.await()
                             if (isSuccess)

--- a/app/src/main/java/com/concordium/wallet/ui/cis2/TokensViewModel.kt
+++ b/app/src/main/java/com/concordium/wallet/ui/cis2/TokensViewModel.kt
@@ -408,7 +408,6 @@ class TokensViewModel(application: Application) : AndroidViewModel(application) 
                     cis2TokensMetadataItem = metadataItem,
                 )
             }
-            // TODO handle incorrect metadata for some tokens.
         } catch (e: IncorrectChecksumException) {
             lookForTokens.postValue(TOKENS_INVALID_CHECKSUM)
         } catch (e: Throwable) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1079,6 +1079,7 @@
     <string name="cis_delete_dialog_cancel">Cancel</string>
     <string name="cis_search_balance">Your balance: %1$s</string>
     <string name="cis_receiver_address_error">The recipient is not registered on the chain</string>
+    <string name="cis_loading_metadata_progress">Loading metadata…</string>
 
     <string name="wallet_connect_transaction_parsing_error">Error parsing the request!</string>
 


### PR DESCRIPTION
## Purpose

This fixes inability to add CIS-2 tokens with corrupted metadata or missing balance. Metadata and balances are loaded asynchronously. In this way, you get the list of tokens pretty fast, and then it fills with extra data. With that, tokens with broken or missing metadata are shown like dummies with no ability to select them, while other tokens, once fully loaded, get the check mark available.

## Changes

- Skip burnt tokens (with total supply 0) during lookup
- Do not let adding tokens without metadata
- Indicate metadata loading progress in tokens list

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.