### PR TITLE
Load all the info before showing a list of found CIS-2 tokens

### DIFF
--- a/app/src/main/java/com/concordium/wallet/data/backend/ProxyBackend.kt
+++ b/app/src/main/java/com/concordium/wallet/data/backend/ProxyBackend.kt
@@ -100,34 +100,27 @@ interface ProxyBackend {
     fun getAccountEncryptedKey(@Path("accountAddress") accountAddress: String): Call<AccountKeyData>
 
     @GET("v0/CIS2Tokens/{index}/{subIndex}")
-    fun cis2Tokens(
+    suspend fun cis2Tokens(
         @Path("index") index: String,
         @Path("subIndex") subIndex: String,
         @Query("from") from: String? = null,
         @Query("limit") limit: Int? = null
-    ): Call<CIS2Tokens>
+    ): CIS2Tokens
 
     @GET("v0/CIS2TokenMetadata/{index}/{subIndex}")
-    fun cis2TokenMetadata(
-        @Path("index") index: String,
-        @Path("subIndex") subIndex: String,
-        @Query("tokenId") tokenId: String
-    ): Call<CIS2TokensMetadata>
-
-    @GET("v0/CIS2TokenMetadata/{index}/{subIndex}")
-    suspend fun cis2TokenMetadataSuspended(
+    suspend fun cis2TokenMetadata(
         @Path("index") index: String,
         @Path("subIndex") subIndex: String,
         @Query("tokenId") tokenId: String
     ): CIS2TokensMetadata
 
     @GET("v0/CIS2TokenBalance/{index}/{subIndex}/{accountAddress}")
-    fun cis2TokenBalance(
+    suspend fun cis2TokenBalance(
         @Path("index") index: String,
         @Path("subIndex") subIndex: String,
         @Path("accountAddress") accountAddress: String,
         @Query("tokenId") tokenId: String
-    ): Call<CIS2TokensBalances>
+    ): CIS2TokensBalances
 
     @GET
     fun checkIdentityProvider(@Url url: String): Call<String>

--- a/app/src/main/java/com/concordium/wallet/data/backend/ProxyBackend.kt
+++ b/app/src/main/java/com/concordium/wallet/data/backend/ProxyBackend.kt
@@ -107,13 +107,6 @@ interface ProxyBackend {
         @Query("limit") limit: Int? = null
     ): CIS2Tokens
 
-    @GET("v0/CIS2TokenMetadata/{index}/{subIndex}")
-    suspend fun cis2TokenMetadata(
-        @Path("index") index: String,
-        @Path("subIndex") subIndex: String,
-        @Query("tokenId") tokenId: String
-    ): CIS2TokensMetadata
-
     @GET("v1/CIS2TokenMetadata/{index}/{subIndex}")
     suspend fun cis2TokenMetadataV1(
         @Path("index") index: String,

--- a/app/src/main/java/com/concordium/wallet/data/backend/ProxyBackend.kt
+++ b/app/src/main/java/com/concordium/wallet/data/backend/ProxyBackend.kt
@@ -114,8 +114,15 @@ interface ProxyBackend {
         @Query("tokenId") tokenId: String
     ): CIS2TokensMetadata
 
-    @GET("v0/CIS2TokenBalance/{index}/{subIndex}/{accountAddress}")
-    suspend fun cis2TokenBalance(
+    @GET("v1/CIS2TokenMetadata/{index}/{subIndex}")
+    suspend fun cis2TokenMetadataV1(
+        @Path("index") index: String,
+        @Path("subIndex") subIndex: String,
+        @Query("tokenId") tokenId: String
+    ): CIS2TokensMetadata
+
+    @GET("v1/CIS2TokenBalance/{index}/{subIndex}/{accountAddress}")
+    suspend fun cis2TokenBalanceV1(
         @Path("index") index: String,
         @Path("subIndex") subIndex: String,
         @Path("accountAddress") accountAddress: String,

--- a/app/src/main/java/com/concordium/wallet/data/backend/repository/ProxyRepository.kt
+++ b/app/src/main/java/com/concordium/wallet/data/backend/repository/ProxyRepository.kt
@@ -408,12 +408,6 @@ class ProxyRepository {
         limit: Int? = null,
     ): CIS2Tokens = backend.cis2Tokens(index, subIndex, from, limit)
 
-    suspend fun getCIS2TokenMetadata(
-        index: String,
-        subIndex: String,
-        tokenIds: String,
-    ): CIS2TokensMetadata = backend.cis2TokenMetadata(index, subIndex, tokenIds)
-
     /**
      * @param tokenIds comma-separated token IDs, but no more than [CIS_2_TOKEN_METADATA_MAX_TOKEN_IDS]
      *

--- a/app/src/main/java/com/concordium/wallet/data/backend/repository/ProxyRepository.kt
+++ b/app/src/main/java/com/concordium/wallet/data/backend/repository/ProxyRepository.kt
@@ -4,7 +4,22 @@ import com.concordium.wallet.App
 import com.concordium.wallet.core.backend.BackendCallback
 import com.concordium.wallet.core.backend.BackendRequest
 import com.concordium.wallet.data.cryptolib.CreateTransferOutput
-import com.concordium.wallet.data.model.*
+import com.concordium.wallet.data.model.AccountBalance
+import com.concordium.wallet.data.model.AccountKeyData
+import com.concordium.wallet.data.model.AccountNonce
+import com.concordium.wallet.data.model.AccountSubmissionStatus
+import com.concordium.wallet.data.model.AccountTransactions
+import com.concordium.wallet.data.model.AppSettings
+import com.concordium.wallet.data.model.BakerPoolStatus
+import com.concordium.wallet.data.model.CIS2Tokens
+import com.concordium.wallet.data.model.CIS2TokensBalances
+import com.concordium.wallet.data.model.CIS2TokensMetadata
+import com.concordium.wallet.data.model.ChainParameters
+import com.concordium.wallet.data.model.CredentialWrapper
+import com.concordium.wallet.data.model.GlobalParamsWrapper
+import com.concordium.wallet.data.model.SubmissionData
+import com.concordium.wallet.data.model.TransferCost
+import com.concordium.wallet.data.model.TransferSubmissionStatus
 import java.math.BigInteger
 
 class ProxyRepository {
@@ -383,83 +398,23 @@ class ProxyRepository {
         )
     }
 
-    fun getCIS2Tokens(
+    suspend fun getCIS2Tokens(
         index: String,
         subIndex: String,
         from: String? = null,
         limit: Int? = null,
-        success: (CIS2Tokens) -> Unit,
-        failure: ((Throwable) -> Unit)?
-    ): BackendRequest<CIS2Tokens> {
-        val call = backend.cis2Tokens(index, subIndex, from, limit)
-        call.enqueue(object : BackendCallback<CIS2Tokens>() {
-            override fun onResponseData(response: CIS2Tokens) {
-                success(response)
-            }
-
-            override fun onFailure(t: Throwable) {
-                failure?.invoke(t)
-            }
-        })
-        return BackendRequest(
-            call = call,
-            success = success,
-            failure = failure
-        )
-    }
-
-    fun getCIS2TokenMetadata(
-        index: String,
-        subIndex: String,
-        tokenIds: String,
-        success: (CIS2TokensMetadata) -> Unit,
-        failure: ((Throwable) -> Unit)?
-    ): BackendRequest<CIS2TokensMetadata> {
-        val call = backend.cis2TokenMetadata(index, subIndex, tokenIds)
-        call.enqueue(object : BackendCallback<CIS2TokensMetadata>() {
-            override fun onResponseData(response: CIS2TokensMetadata) {
-                success(response)
-            }
-
-            override fun onFailure(t: Throwable) {
-                failure?.invoke(t)
-            }
-        })
-        return BackendRequest(
-            call = call,
-            success = success,
-            failure = failure
-        )
-    }
+    ): CIS2Tokens = backend.cis2Tokens(index, subIndex, from, limit)
 
     suspend fun getCIS2TokenMetadataSuspended(
         index: String,
         subIndex: String,
         tokenIds: String,
-    ) = backend.cis2TokenMetadataSuspended(index, subIndex, tokenIds)
+    ): CIS2TokensMetadata = backend.cis2TokenMetadata(index, subIndex, tokenIds)
 
-    fun getCIS2TokenBalance(
+    suspend fun getCIS2TokenBalance(
         index: String,
         subIndex: String,
         accountAddress: String,
         tokenIds: String,
-        success: (CIS2TokensBalances) -> Unit,
-        failure: ((Throwable) -> Unit)?
-    ): BackendRequest<CIS2TokensBalances> {
-        val call = backend.cis2TokenBalance(index, subIndex, accountAddress, tokenIds)
-        call.enqueue(object : BackendCallback<CIS2TokensBalances>() {
-            override fun onResponseData(response: CIS2TokensBalances) {
-                success(response)
-            }
-
-            override fun onFailure(t: Throwable) {
-                failure?.invoke(t)
-            }
-        })
-        return BackendRequest(
-            call = call,
-            success = success,
-            failure = failure
-        )
-    }
+    ): CIS2TokensBalances = backend.cis2TokenBalance(index, subIndex, accountAddress, tokenIds)
 }

--- a/app/src/main/java/com/concordium/wallet/data/backend/repository/ProxyRepository.kt
+++ b/app/src/main/java/com/concordium/wallet/data/backend/repository/ProxyRepository.kt
@@ -40,6 +40,9 @@ class ProxyRepository {
         const val REMOVE_BAKER = "removeBaker"
         const val CONFIGURE_BAKER = "configureBaker"
         const val UPDATE = "update"
+
+        const val CIS_2_TOKEN_BALANCE_MAX_TOKEN_IDS = 20
+        const val CIS_2_TOKEN_METADATA_MAX_TOKEN_IDS = 20
     }
 
     fun submitCredential(
@@ -405,16 +408,32 @@ class ProxyRepository {
         limit: Int? = null,
     ): CIS2Tokens = backend.cis2Tokens(index, subIndex, from, limit)
 
-    suspend fun getCIS2TokenMetadataSuspended(
+    suspend fun getCIS2TokenMetadata(
         index: String,
         subIndex: String,
         tokenIds: String,
     ): CIS2TokensMetadata = backend.cis2TokenMetadata(index, subIndex, tokenIds)
 
-    suspend fun getCIS2TokenBalance(
+    /**
+     * @param tokenIds comma-separated token IDs, but no more than [CIS_2_TOKEN_METADATA_MAX_TOKEN_IDS]
+     *
+     * @return metadata items for tokens having it
+     */
+    suspend fun getCIS2TokenMetadataV1(
+        index: String,
+        subIndex: String,
+        tokenIds: String,
+    ): CIS2TokensMetadata = backend.cis2TokenMetadataV1(index, subIndex, tokenIds)
+
+    /**
+     * @param tokenIds comma-separated token IDs, but no more than [CIS_2_TOKEN_BALANCE_MAX_TOKEN_IDS]
+
+     * @return balance items for tokens having it
+     */
+    suspend fun getCIS2TokenBalanceV1(
         index: String,
         subIndex: String,
         accountAddress: String,
         tokenIds: String,
-    ): CIS2TokensBalances = backend.cis2TokenBalance(index, subIndex, accountAddress, tokenIds)
+    ): CIS2TokensBalances = backend.cis2TokenBalanceV1(index, subIndex, accountAddress, tokenIds)
 }

--- a/app/src/main/java/com/concordium/wallet/ui/cis2/TokensViewModel.kt
+++ b/app/src/main/java/com/concordium/wallet/ui/cis2/TokensViewModel.kt
@@ -43,9 +43,6 @@ class TokensViewModel(application: Application) : AndroidViewModel(application) 
         const val TOKENS_NOT_LOADED = -1
         const val TOKENS_OK = 0
         const val TOKENS_EMPTY = 1
-        const val TOKENS_INVALID_INDEX = 2
-        const val TOKENS_METADATA_ERROR = 3
-        const val TOKENS_INVALID_CHECKSUM = 4
     }
 
     private var allowToLoadMore = true

--- a/app/src/main/java/com/concordium/wallet/ui/cis2/TokensViewModel.kt
+++ b/app/src/main/java/com/concordium/wallet/ui/cis2/TokensViewModel.kt
@@ -129,7 +129,7 @@ class TokensViewModel(application: Application) : AndroidViewModel(application) 
         accountAddress: String,
         from: String? = null,
     ) = viewModelScope.launch(Dispatchers.IO) {
-        if (!allowToLoadMore)
+        if (from != null && !allowToLoadMore)
             return@launch
 
         allowToLoadMore = false

--- a/app/src/main/java/com/concordium/wallet/ui/cis2/lookfornew/ContractAddressFragment.kt
+++ b/app/src/main/java/com/concordium/wallet/ui/cis2/lookfornew/ContractAddressFragment.kt
@@ -156,9 +156,6 @@ class ContractAddressFragment : TokensBaseFragment() {
     private fun getTokenErrorMessage(result: Int): String {
         return when (result) {
             TokensViewModel.TOKENS_EMPTY -> getString(R.string.cis_find_tokens_none)
-            TokensViewModel.TOKENS_INVALID_INDEX -> getString(R.string.cis_find_tokens_invalid_index)
-            TokensViewModel.TOKENS_METADATA_ERROR -> getString(R.string.cis_find_tokens_metadata_error)
-            TokensViewModel.TOKENS_INVALID_CHECKSUM -> getString(R.string.cis_find_tokens_invalid_checksum)
             else -> ""
         }
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1027,10 +1027,7 @@
     <string name="cis_select_tokens_title">Please select the tokens you want to add from the contract.</string>
     <string name="cis_add_tokens">Add tokens</string>
     <string name="cis_update_tokens">Update tokens</string>
-    <string name="cis_find_tokens_none">This contract has no tokens.</string>
-    <string name="cis_find_tokens_invalid_index">Invalid contract index</string>
-    <string name="cis_find_tokens_metadata_error">Unable to load metadata</string>
-    <string name="cis_find_tokens_invalid_checksum">Token metadata has an invalid checksum</string>
+    <string name="cis_find_tokens_none">This contract has no valid tokens</string>
     <string name="cis_search">Search for token ID</string>
     <string name="cis_send_funds">Send funds</string>
     <string name="cis_currently_available_amounts">Currently available amounts:</string>


### PR DESCRIPTION
## Purpose

This is a second part of [more lenient CIS-2 Lookup](https://concordium.atlassian.net/browse/CBW-1600).

## Changes

- Load token metadata and balances before showing the list of found tokens
- Filter out tokens with corrupted or missing metadata
- Show "This contract has no valid tokens" if all the contract tokens are invalid
- Get rid of token lookup errors made obsolete by this change (invalid index, invalid metadata, invalid metadata checksum)

Internally:
- Use new fail-proof batch endpoints to fetch metadata and balance info

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.