### PR TITLE
Fix use of env name instead of chain for key export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed:
 
 - Inability to add CIS-2 tokens with corrupted metadata or missing balance
+- Writing incorrect `environment` value to the key export file
 
 ## [1.5.0]
 

--- a/app/src/main/java/com/concordium/wallet/ui/more/export/ExportAccountKeysViewModel.kt
+++ b/app/src/main/java/com/concordium/wallet/ui/more/export/ExportAccountKeysViewModel.kt
@@ -39,7 +39,7 @@ class ExportAccountKeysViewModel(application: Application) : AndroidViewModel(ap
                 ExportAccountKeys(
                     "concordium-browser-wallet-account",
                     account.credential?.v ?: 0,
-                    BuildConfig.ENV_NAME,
+                    BuildConfig.EXPORT_CHAIN,
                     value
                 )
             )


### PR DESCRIPTION
Incorrect value was written to `environment` for Mainnet and Testnet.

## Purpose

Fix writing incorrect `environment` value to the key export file. Incorrect values was written for Mainnet and Testnet.

## Changes

- Fix writing incorrect `environment` value to the key export file

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.
