### PR TITLE
Fix inability to search for CIS-2 token by its ID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Inability to add CIS-2 tokens with corrupted metadata or missing balance
 - Writing incorrect `environment` value to the key export file
 - Inability to edit validator pool commission rates in locales with comma decimal separator
+- Inability to search for CIS-2 token by ID on contracts with lots of tokens
+- When managing CIS-2 tokens, removing all of them when only unselecting the visible ones 
 
 ## [1.5.0]
 

--- a/app/src/main/java/com/concordium/wallet/ui/cis2/TokensViewModel.kt
+++ b/app/src/main/java/com/concordium/wallet/ui/cis2/TokensViewModel.kt
@@ -372,7 +372,12 @@ class TokensViewModel(application: Application) : AndroidViewModel(application) 
     }
 
     fun toggleNewToken(token: Token) {
-        tokens.firstOrNull { it.id == token.id }?.let {
+        // Update both unfiltered search result and the exact token
+        // in case the target token is in both places.
+        tokens.firstOrNull { it.token == token.token }?.let {
+            it.isSelected = it.isSelected == false
+        }
+        exactToken?.takeIf { it.token == token.token }?.let {
             it.isSelected = it.isSelected == false
         }
     }
@@ -614,6 +619,7 @@ class TokensViewModel(application: Application) : AndroidViewModel(application) 
         stepPageBy.value = 0
         lookForTokens.value = TOKENS_NOT_LOADED
         lookForExactToken.value = TOKENS_NOT_LOADED
+        exactToken = null
         allowToLoadMore = true
     }
 


### PR DESCRIPTION
## Purpose

Make the search field do the exact token lookup instead of filtering the current list of found tokens, which may be partial. [WAL2-69](https://linear.app/concordium/issue/WAL2-69/not-possible-to-add-tokens-in-android-wallet-in-some-cases)

## Changes

- Update the "Search by token ID" field logic
- Simplify `updateWithSelectedTokens` which also fixes removing all of added CIS-2 tokens when only unselecting the visible ones when managing

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.