### PR TITLE
UFT-1398 Fix WalletConnect cost estimation failing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- Sending WalletConnect transaction with 0 energy if its payload is too large
+
 ## [1.5.1] - 2024-03-18
 
 ### Fixed

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -42,9 +42,9 @@ tasks.withType(Test) {
 
 def versionBuildNumberMajor = 1
 def versionBuildNumberMinor = 5
-def versionBuildNumberPatch = 1
-def versionBuildNumberMeta = ""
-def versionBuildNumberSequential = 70
+def versionBuildNumberPatch = 2
+def versionBuildNumberMeta = "-qa.1"
+def versionBuildNumberSequential = 71
 
 task printVersionName {
     doLast {

--- a/app/src/main/java/com/concordium/wallet/data/model/ChainParameters.kt
+++ b/app/src/main/java/com/concordium/wallet/data/model/ChainParameters.kt
@@ -1,5 +1,6 @@
 package com.concordium.wallet.data.model
 
+import com.google.gson.annotations.SerializedName
 import java.io.Serializable
 import java.math.BigInteger
 
@@ -20,4 +21,7 @@ data class ChainParameters(
     val transactionCommissionRange: TransactionCommissionRange,
     val transactionCommissionRate: Double? = null,
     val finalizationCommissionRange: FinalizationCommissionRange,
+    val euroPerEnergy: SimpleFraction,
+    @SerializedName("microGTUPerEuro")
+    val microGtuPerEuro: SimpleFraction,
 ) : Serializable

--- a/app/src/main/java/com/concordium/wallet/data/model/SimpleFraction.kt
+++ b/app/src/main/java/com/concordium/wallet/data/model/SimpleFraction.kt
@@ -1,0 +1,16 @@
+package com.concordium.wallet.data.model
+
+import java.math.BigInteger
+
+/**
+ * A fraction defined as 2 integers:
+ * ```
+ *  N
+ *  –
+ *  D
+ * ```
+ */
+data class SimpleFraction(
+    val numerator: BigInteger,
+    val denominator: BigInteger,
+)

--- a/app/src/main/java/com/concordium/wallet/data/model/TransferCost.kt
+++ b/app/src/main/java/com/concordium/wallet/data/model/TransferCost.kt
@@ -1,7 +1,20 @@
 package com.concordium.wallet.data.model
 
+import java.math.BigInteger
+
 data class TransferCost(
     val energy: Long,
-    val cost: String,
+    val cost: BigInteger,
     val success: Boolean?
-)
+){
+    constructor(
+        energy: Long,
+        euroPerEnergy: SimpleFraction,
+        microGTUPerEuro: SimpleFraction,
+    ) : this(
+        energy = energy,
+        cost = (energy.toBigInteger() * euroPerEnergy.numerator * microGTUPerEuro.numerator)
+            .divide(euroPerEnergy.denominator * microGTUPerEuro.denominator),
+        success = null,
+    )
+}

--- a/app/src/main/java/com/concordium/wallet/data/util/TransactionCostCalculator.kt
+++ b/app/src/main/java/com/concordium/wallet/data/util/TransactionCostCalculator.kt
@@ -1,0 +1,65 @@
+package com.concordium.wallet.data.util
+
+import com.walletconnect.util.hexToBytes
+import okio.utf8Size
+
+/**
+ * Local transaction cost calculations.
+ *
+ * @see <a href="https://github.com/Concordium/concordium-rust-sdk/blob/01b00f7a82e62d3642be51282e6a89045727759d/src/types/transactions.rs#L1276">Rust SDK reference methods</a>
+ */
+object TransactionCostCalculator {
+    /**
+     * Base cost of a transaction is the minimum cost that accounts for
+     * transaction size and signature checking. In addition to base cost
+     * each transaction has a transaction-type specific cost.
+     *
+     * @param transactionSize size of the transaction, for example [getContractTransactionSize].
+     * @param numSignatures number of signatures, which is 1 unless we implement multisig in the wallet.
+     *
+     * @return energy required to execute this transaction.
+     */
+    fun getBaseCostEnergy(
+        transactionSize: Long,
+        numSignatures: Int = 1,
+    ): Long =
+        B * transactionSize + A * numSignatures
+
+    /**
+     * @param receiveName `contractName.methodName`.
+     * @param message serialized parameters in hex.
+     *
+     * @return size in bytes of a transaction invoking a smart contract.
+     */
+    fun getContractTransactionSize(
+        receiveName: String,
+        message: String,
+    ): Long =
+        TRANSACTION_HEADER_SIZE +
+                TRANSACTION_TAG_SIZE +
+                8 + 16 +
+                2 + receiveName.utf8Size() +
+                2 + message.hexToBytes().size
+
+    /**
+     * The B constant for NRG assignment.
+     * This scales the effect of the number of signatures on the energy.
+     */
+    private const val A: Long = 100
+
+    /**
+     * The A constant for NRG assignment.
+     * This scales the effect of transaction size on the energy.
+     */
+    private const val B: Long = 1
+
+    /**
+     * Size of a transaction header.
+     * This is currently always 60 bytes.
+     * Future chain updates might revise this,
+     * but this is a big change so this is expected to change seldomly.
+     */
+    private const val TRANSACTION_HEADER_SIZE: Long = 32 + 8 + 8 + 4 + 8
+
+    private const val TRANSACTION_TAG_SIZE: Long = 1
+}

--- a/app/src/main/java/com/concordium/wallet/data/walletconnect/Payload.kt
+++ b/app/src/main/java/com/concordium/wallet/data/walletconnect/Payload.kt
@@ -4,8 +4,16 @@ sealed interface Payload {
     data class ContractUpdateTransaction(
         val address: ContractAddress,
         val amount: String,
-        var maxEnergy: Long,
-        var maxContractExecutionEnergy: Long,
+        /**
+         * Energy for the whole transaction including the administrative fee.
+         * Legacy field.
+         */
+        val maxEnergy: Long?,
+        /**
+         * Energy for the smart contract execution only,
+         * without the administrative transaction fee.
+         */
+        val maxContractExecutionEnergy: Long?,
         val message: String,
         val receiveName: String
     ) : Payload

--- a/app/src/main/java/com/concordium/wallet/ui/bakerdelegation/common/DelegationBakerViewModel.kt
+++ b/app/src/main/java/com/concordium/wallet/ui/bakerdelegation/common/DelegationBakerViewModel.kt
@@ -48,7 +48,6 @@ import com.concordium.wallet.data.util.FileUtil
 import com.concordium.wallet.ui.common.BackendErrorHandler
 import com.concordium.wallet.util.DateTimeUtil
 import com.concordium.wallet.util.Log
-import com.concordium.wallet.util.toBigInteger
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
@@ -358,7 +357,7 @@ class DelegationBakerViewModel(application: Application) : AndroidViewModel(appl
             openStatus = openStatus,
             success = {
                 bakerDelegationData.energy = it.energy
-                bakerDelegationData.cost = it.cost.toBigInteger()
+                bakerDelegationData.cost = it.cost
                 if (notifyObservers)
                     _transactionFeeLiveData.value = Pair(bakerDelegationData.cost, requestId)
             },

--- a/app/src/main/java/com/concordium/wallet/ui/cis2/SendTokenViewModel.kt
+++ b/app/src/main/java/com/concordium/wallet/ui/cis2/SendTokenViewModel.kt
@@ -41,7 +41,6 @@ import com.concordium.wallet.ui.common.BackendErrorHandler
 import com.concordium.wallet.util.DateTimeUtil
 import com.concordium.wallet.util.Log
 import com.concordium.wallet.util.TokenUtil
-import com.concordium.wallet.util.toBigInteger
 import com.concordium.wallet.util.toHex
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -275,7 +274,7 @@ class SendTokenViewModel(application: Application) : AndroidViewModel(applicatio
                     handleBackendError(TransactionSimulationException())
                 } else {
                     sendTokenData.energy = it.energy
-                    sendTokenData.fee = it.cost.toBigInteger()
+                    sendTokenData.fee = it.cost
                     sendTokenData.account?.let { account ->
                         sendTokenData.max =
                             account.getAtDisposalWithoutStakedOrScheduled(account.totalUnshieldedBalance) -
@@ -313,7 +312,7 @@ class SendTokenViewModel(application: Application) : AndroidViewModel(applicatio
                     handleBackendError(TransactionSimulationException())
                 } else {
                     sendTokenData.energy = it.energy
-                    sendTokenData.fee = it.cost.toBigInteger()
+                    sendTokenData.fee = it.cost
                     waiting.postValue(false)
                     feeReady.postValue(sendTokenData.fee)
                 }

--- a/app/src/main/java/com/concordium/wallet/ui/transaction/sendfunds/SendFundsViewModel.kt
+++ b/app/src/main/java/com/concordium/wallet/ui/transaction/sendfunds/SendFundsViewModel.kt
@@ -210,7 +210,7 @@ class SendFundsViewModel(application: Application) : AndroidViewModel(applicatio
             memoSize = if (tempData.memo == null) null else tempData.memo!!.length / 2, //div by 2 because hex takes up twice the length
             success = {
                 tempData.energy = it.energy
-                _transactionFeeLiveData.value = it.cost.toBigInteger()
+                _transactionFeeLiveData.value = it.cost
                 updateSendAllAmount()
             },
             failure = {


### PR DESCRIPTION

## Purpose

Fix WalletConnect cost estimation failing if the smart contract call parameters are large.
The changes are the same as in https://github.com/Concordium/cryptox-android/pull/26

## Changes

- Replace asking wallet proxy for transaction cost with local fee estimation for WalletConnect Update transactions

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
