### PR TITLE
WAL2-85 Fix crash on validator setup flow

### DIFF
--- a/app/src/main/java/com/concordium/wallet/data/model/SimpleFraction.kt
+++ b/app/src/main/java/com/concordium/wallet/data/model/SimpleFraction.kt
@@ -1,5 +1,6 @@
 package com.concordium.wallet.data.model
 
+import java.io.Serializable
 import java.math.BigInteger
 
 /**
@@ -10,7 +11,7 @@ import java.math.BigInteger
  *  D
  * ```
  */
-data class SimpleFraction(
+class SimpleFraction(
     val numerator: BigInteger,
     val denominator: BigInteger,
-)
+): Serializable


### PR DESCRIPTION
## Purpose

The crash was caused by missing Serializable marker on SimpleFraction, introduced with WC cost estimation fix.

## Changes

- Add missing Serializable marker on SimpleFraction

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
